### PR TITLE
Deprecate old package and method keeping the new ones to avoid build failures

### DIFF
--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.common/src/main/java/com/wso2/openbanking/accelerator/common/util/JWTUtils.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.common/src/main/java/com/wso2/openbanking/accelerator/common/util/JWTUtils.java
@@ -101,56 +101,6 @@ public class JWTUtils {
      * @throws MalformedURLException if an error occurs while creating the URL object
      */
     @Generated(message = "Excluding from code coverage since can not call this method due to external https call")
-    public static boolean isValidSignature(String jwtString, String jwksUri, String algorithm)
-            throws ParseException, BadJOSEException, JOSEException, MalformedURLException {
-
-        int defaultConnectionTimeout = 3000;
-        int defaultReadTimeout = 3000;
-        ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
-        JWT jwt = JWTParser.parse(jwtString);
-        // set the Key Selector for the jwks_uri.
-        Map<String, RemoteJWKSet<SecurityContext>> jwkSourceMap = new ConcurrentHashMap<>();
-        RemoteJWKSet<SecurityContext> jwkSet = jwkSourceMap.get(jwksUri);
-        if (jwkSet == null) {
-            int connectionTimeout = Integer.parseInt(OpenBankingConfigParser.getInstance().getJWKSConnectionTimeOut());
-            int readTimeout = Integer.parseInt(OpenBankingConfigParser.getInstance().getJWKSReadTimeOut());
-            int sizeLimit = RemoteJWKSet.DEFAULT_HTTP_SIZE_LIMIT;
-            if (connectionTimeout == 0 && readTimeout == 0) {
-                connectionTimeout = defaultConnectionTimeout;
-                readTimeout = defaultReadTimeout;
-            }
-            DefaultResourceRetriever resourceRetriever = new DefaultResourceRetriever(
-                    connectionTimeout,
-                    readTimeout,
-                    sizeLimit);
-            jwkSet = new RemoteJWKSet<>(new URL(jwksUri), resourceRetriever);
-            jwkSourceMap.put(jwksUri, jwkSet);
-        }
-        // The expected JWS algorithm of the access tokens (agreed out-of-band).
-        JWSAlgorithm expectedJWSAlg = JWSAlgorithm.parse(algorithm);
-        //Configure the JWT processor with a key selector to feed matching public RSA keys sourced from the JWK set URL.
-        JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, jwkSet);
-        jwtProcessor.setJWSKeySelector(keySelector);
-        // Process the token, set optional context parameters.
-        SimpleSecurityContext securityContext = new SimpleSecurityContext();
-        jwtProcessor.process((SignedJWT) jwt, securityContext);
-        return true;
-    }
-
-    /**
-     * Validate the signed JWT by querying a jwks.
-     *
-     * @param jwtString signed json web token
-     * @param jwksUri   endpoint displaying the key set for the signing certificates
-     * @param algorithm the signing algorithm for jwt
-     * @return true if signature is valid
-     * @throws ParseException    if an error occurs while parsing the jwt
-     * @throws BadJOSEException  if the jwt is invalid
-     * @throws JOSEException     if an error occurs while processing the jwt
-     * @throws MalformedURLException if an error occurs while creating the URL object
-     */
-    @Deprecated
-    @Generated(message = "Excluding from code coverage since can not call this method due to external https call")
     public static boolean validateJWTSignature(String jwtString, String jwksUri, String algorithm)
             throws ParseException, BadJOSEException, JOSEException, MalformedURLException {
 

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.common/src/main/java/com/wso2/openbanking/accelerator/common/util/JWTUtils.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.common/src/main/java/com/wso2/openbanking/accelerator/common/util/JWTUtils.java
@@ -138,6 +138,56 @@ public class JWTUtils {
     }
 
     /**
+     * Validate the signed JWT by querying a jwks.
+     *
+     * @param jwtString signed json web token
+     * @param jwksUri   endpoint displaying the key set for the signing certificates
+     * @param algorithm the signing algorithm for jwt
+     * @return true if signature is valid
+     * @throws ParseException    if an error occurs while parsing the jwt
+     * @throws BadJOSEException  if the jwt is invalid
+     * @throws JOSEException     if an error occurs while processing the jwt
+     * @throws MalformedURLException if an error occurs while creating the URL object
+     */
+    @Deprecated
+    @Generated(message = "Excluding from code coverage since can not call this method due to external https call")
+    public static boolean validateJWTSignature(String jwtString, String jwksUri, String algorithm)
+            throws ParseException, BadJOSEException, JOSEException, MalformedURLException {
+
+        int defaultConnectionTimeout = 3000;
+        int defaultReadTimeout = 3000;
+        ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+        JWT jwt = JWTParser.parse(jwtString);
+        // set the Key Selector for the jwks_uri.
+        Map<String, RemoteJWKSet<SecurityContext>> jwkSourceMap = new ConcurrentHashMap<>();
+        RemoteJWKSet<SecurityContext> jwkSet = jwkSourceMap.get(jwksUri);
+        if (jwkSet == null) {
+            int connectionTimeout = Integer.parseInt(OpenBankingConfigParser.getInstance().getJWKSConnectionTimeOut());
+            int readTimeout = Integer.parseInt(OpenBankingConfigParser.getInstance().getJWKSReadTimeOut());
+            int sizeLimit = RemoteJWKSet.DEFAULT_HTTP_SIZE_LIMIT;
+            if (connectionTimeout == 0 && readTimeout == 0) {
+                connectionTimeout = defaultConnectionTimeout;
+                readTimeout = defaultReadTimeout;
+            }
+            DefaultResourceRetriever resourceRetriever = new DefaultResourceRetriever(
+                    connectionTimeout,
+                    readTimeout,
+                    sizeLimit);
+            jwkSet = new RemoteJWKSet<>(new URL(jwksUri), resourceRetriever);
+            jwkSourceMap.put(jwksUri, jwkSet);
+        }
+        // The expected JWS algorithm of the access tokens (agreed out-of-band).
+        JWSAlgorithm expectedJWSAlg = JWSAlgorithm.parse(algorithm);
+        //Configure the JWT processor with a key selector to feed matching public RSA keys sourced from the JWK set URL.
+        JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, jwkSet);
+        jwtProcessor.setJWSKeySelector(keySelector);
+        // Process the token, set optional context parameters.
+        SimpleSecurityContext securityContext = new SimpleSecurityContext();
+        jwtProcessor.process((SignedJWT) jwt, securityContext);
+        return true;
+    }
+
+    /**
      * Validates the signature of a given JWT against a given public key.
      *
      * @param signedJWT the signed JWT to be validated

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.common/src/main/java/com/wso2/openbanking/accelerator/common/util/JWTUtils.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.common/src/main/java/com/wso2/openbanking/accelerator/common/util/JWTUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/executor/dcr/DCRExecutor.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/executor/dcr/DCRExecutor.java
@@ -920,7 +920,7 @@ public class DCRExecutor implements OpenBankingGatewayExecutor {
         String jwksEndpoint = decodedSSA.getAsString(jwksEndpointName);
         SignedJWT signedJWT = SignedJWT.parse(payload);
         String alg = signedJWT.getHeader().getAlgorithm().getName();
-        JWTUtils.isValidSignature(payload, jwksEndpoint, alg);
+        JWTUtils.validateJWTSignature(payload, jwksEndpoint, alg);
         obapiRequestContext.setModifiedPayload(decodedRequest.toJSONString());
         Map<String, String> requestHeaders = obapiRequestContext.getMsgInfo().getHeaders();
         requestHeaders.remove("Content-Type");

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/SignatureValidator.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/SignatureValidator.java
@@ -98,7 +98,7 @@ public class SignatureValidator implements ConstraintValidator<ValidateSignature
     private boolean isValidateJWTSignature(String jwksURL, String jwtString, String alg) {
 
         try {
-            return JWTUtils.isValidSignature(jwtString, jwksURL, alg);
+            return JWTUtils.validateJWTSignature(jwtString, jwksURL, alg);
         } catch (ParseException e) {
             log.error("Error while parsing the JWT string", e);
         } catch (JOSEException | BadJOSEException | MalformedURLException e) {

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/AttributeChecks.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/AttributeChecks.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.identity.dcr.validation.validationgroups;
+
+/**
+ * Interface for grouping the validation annotations.
+ * Groups the validations for attributes
+ */
+@Deprecated
+public interface AttributeChecks {
+
+}
+

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/AttributeChecks.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/AttributeChecks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/MandatoryChecks.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/MandatoryChecks.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.identity.dcr.validation.validationgroups;
+
+/**
+ * Interface for grouping the validation annotations.
+ * Grouping the mandatory check constraints
+ */
+@Deprecated
+public interface MandatoryChecks {
+
+}
+

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/MandatoryChecks.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/MandatoryChecks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/SignatureCheck.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/SignatureCheck.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.identity.dcr.validation.validationgroups;
+
+/**
+ * Interface for grouping the validation annotations.
+ * Groups the validation for signature
+ */
+@Deprecated
+public interface SignatureCheck {
+
+}
+

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/SignatureCheck.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/SignatureCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/ValidationOrder.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/ValidationOrder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/ValidationOrder.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/ValidationOrder.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.wso2.openbanking.accelerator.identity.dcr.validation.validationgroups;
+
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.AttributeChecks;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.MandatoryChecks;
+import com.wso2.openbanking.accelerator.identity.common.annotations.validationgroups.SignatureCheck;
+
+import javax.validation.GroupSequence;
+
+/**
+ * Class to define the order of execution for the hibernate validation groups.
+ */
+@GroupSequence({MandatoryChecks.class, AttributeChecks.class, SignatureCheck.class})
+@Deprecated
+public interface ValidationOrder {
+
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/ValidityChecks.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/dcr/validation/validationgroups/ValidityChecks.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.identity.dcr.validation.validationgroups;
+
+/**
+ * Interface for grouping the validation annotations.
+ * Groups the validations for the validity of a JWT
+ */
+@Deprecated
+public interface ValidityChecks {
+
+}
+


### PR DESCRIPTION
## Deprecate old package and method keeping the new ones to avoid build failures

> Deprecate the old validationorder package and introduce a new package.
> Deprecate the old ```validateJWTSignature ``` method and keep the same method with the name ```isValidSignature ``` to avoid build failures.

**Issue link:** 

**Doc Issue:** 

**Applicable Labels:** *Accelerator*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
