### PR TITLE
Fix unnecessary account mapping update in application deletion

### DIFF
--- a/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/ConsentCoreServiceImpl.java
+++ b/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/ConsentCoreServiceImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/ConsentCoreServiceImpl.java
+++ b/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/ConsentCoreServiceImpl.java
@@ -506,9 +506,10 @@ public class ConsentCoreServiceImpl implements ConsentCoreService {
 
                 // Update account mappings as inactive
                 log.debug("Deactivating account mappings");
-                consentCoreDAO.updateConsentMappingStatus(connection, accountMappingIDsList,
-                        ConsentCoreServiceConstants.INACTIVE_MAPPING_STATUS);
-
+                if (accountMappingIDsList.size() > 0) {
+                    consentCoreDAO.updateConsentMappingStatus(connection, accountMappingIDsList,
+                            ConsentCoreServiceConstants.INACTIVE_MAPPING_STATUS);
+                }
                 //Commit transaction
                 DatabaseUtil.commitTransaction(connection);
                 log.debug(ConsentCoreServiceConstants.TRANSACTION_COMMITTED_LOG_MSG);


### PR DESCRIPTION
## Fix unnecessary account mapping update in application deletion

> This PR fixes the issue of calling `consentCoreDAO.updateConsentMappingStatus()` in application deletion even when there are no consents for the particular application.

**Issue link:** *https://github.com/wso2/financial-open-banking/issues/81*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
