### PR TITLE
Fix issue of PAR response returning wrong error code when mandatory params not present in the client assertion

### DIFF
--- a/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.accelerator.push.authorization.endpoint/src/main/java/com/wso2/openbanking/accelerator/push/authorization/endpoint/api/PushAuthorisationEndpoint.java
+++ b/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.accelerator.push.authorization.endpoint/src/main/java/com/wso2/openbanking/accelerator/push/authorization/endpoint/api/PushAuthorisationEndpoint.java
@@ -95,16 +95,6 @@ public class PushAuthorisationEndpoint {
         OAuthClientAuthnContext clientAuthnContext = (OAuthClientAuthnContext)
                 request.getAttribute(CLIENT_AUTHENTICATION_CONTEXT);
 
-        // Check if the client authentication is successful
-        if (!clientAuthnContext.isAuthenticated()) {
-            // create error response
-            PushAuthErrorResponse errorResponse = pushAuthRequestValidator
-                    .createErrorResponse(HttpServletResponse.SC_UNAUTHORIZED,
-                            clientAuthnContext.getErrorCode(), clientAuthnContext.getErrorMessage());
-            return Response.status(errorResponse.getHttpStatusCode())
-                    .entity(errorResponse.getPayload()).build();
-        }
-
         try {
             paramMap = pushAuthRequestValidator.validateParams(request, (Map<String, List<String>>) parameterMap);
         } catch (PushAuthRequestValidatorException exception) {
@@ -113,7 +103,17 @@ public class PushAuthorisationEndpoint {
                     .createErrorResponse(exception.getHttpStatusCode(), exception.getErrorCode(),
                             exception.getErrorDescription());
             return Response.status(errorResponse.getHttpStatusCode() != 0 ?
-                    errorResponse.getHttpStatusCode() : exception.getHttpStatusCode())
+                            errorResponse.getHttpStatusCode() : exception.getHttpStatusCode())
+                    .entity(errorResponse.getPayload()).build();
+        }
+
+        // Check if the client authentication is successful
+        if (!clientAuthnContext.isAuthenticated()) {
+            // create error response
+            PushAuthErrorResponse errorResponse = pushAuthRequestValidator
+                    .createErrorResponse(HttpServletResponse.SC_UNAUTHORIZED,
+                            clientAuthnContext.getErrorCode(), clientAuthnContext.getErrorMessage());
+            return Response.status(errorResponse.getHttpStatusCode())
                     .entity(errorResponse.getPayload()).build();
         }
 


### PR DESCRIPTION
## Fix issue of PAR response returning wrong error code when mandatory params not present in the client assertion

**Related Issue link:** https://github.com/wso2/financial-services-accelerator/issues/196

**Doc Issue:** N/A

**Applicable Labels:** Accelerator, CDS Toolkit

------

### Development Checklist

1. [x] Built complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Documented test scenarios(link available in guides).
3. [ ] Written automation tests (link available in guides).
4. [ ] Verified tests in multiple database environments (if applicable).
5. [ ] Verified tests in multiple deployed specifications (if applicable).
6. [ ] Tested with OBBI enabled  (if applicable).
7. [ ] Tested with specification regulatory conformance suites  (if applicable).

**Automation Test Details**

| Test Suite        | Test Script IDs   |
| ----------------- | ----------------- |
| Integration Suite | *TCXXXXX, TCXXXX* |

**Conformance Tests Details**

| Test Suite Name  | Test Suite Version | Scenarios  | Result   |
| ---------------- | ------------------ | ---------- | -------- |
| *Security Suite* | *VX.X*             | *Foo, Bar* | *Passed* |

## Resources

**Knowledge Base:** https://sites.google.com/wso2.com/open-banking/

**Guides:** https://sites.google.com/wso2.com/open-banking/developer-guides
