### PR TITLE
[OB3] Fix x-jws-signature header is getting duplicated for error scenarios

### DIFF
--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/handler/JwsResponseSignatureHandler.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/handler/JwsResponseSignatureHandler.java
@@ -36,6 +36,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 
@@ -170,6 +171,17 @@ public class JwsResponseSignatureHandler extends AbstractSynapseHandler {
 
         if (payloadString.isPresent()) {
             try {
+                // If the signature header already exists, remove it before adding a new one.
+                // Headers are case-insensitive.
+                Iterator headersIterator = headers.entrySet().iterator();
+                while (headersIterator.hasNext()) {
+                    Map.Entry entry = (Map.Entry) headersIterator.next();
+                    if (entry.getKey() instanceof String &&
+                            ((String) entry.getKey()).equalsIgnoreCase(signatureHeaderName)) {
+                        headersIterator.remove();
+                        log.debug("Removing existing signature header: " + entry.getKey());
+                    }
+                }
                 headers.put(signatureHeaderName, generateJWSSignature(payloadString));
             } catch (JOSEException | OpenBankingException e) {
                 log.error("Unable to sign response", e);


### PR DESCRIPTION
## [OB3] Fix x-jws-signature header is getting duplicated for error scenarios

> $subject

This PR is added to fix $subject.

**Issue link:** 
https://github.com/wso2/financial-services-accelerator/issues/739

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** UK Toolkit

------

### Development Checklist

1. [X] Built complete solution with pull request in place.
5. [X] Ran checkstyle plugin with pull request in place.
6. [X] Ran Findbugs plugin with pull request in place.
7. [X] Ran FindSecurityBugs plugin and verified report.
8. [X] Formatted code according to WSO2 code style.
9. [X] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
10. [ ] Migration scripts written (if applicable).
11. [X] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Documented test scenarios(link available in guides).
3. [ ] Written automation tests (link available in guides).
4. [ ] Verified tests in multiple database environments (if applicable).
5. [ ] Verified tests in multiple deployed specifications (if applicable).
6. [ ] Tested with OBBI enabled  (if applicable).
7. [ ] Tested with specification regulatory conformance suites  (if applicable).

## Resources

**Knowledge Base:** https://sites.google.com/wso2.com/open-banking/

**Guides:** https://sites.google.com/wso2.com/open-banking/developer-guides
