### PR TITLE
[OB3] Fix consent manager login failure due to missing dependency

### DIFF
--- a/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.accelerator.application.info.endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.accelerator.application.info.endpoint/src/main/webapp/WEB-INF/web.xml
@@ -58,6 +58,10 @@
                 com.wso2.open.banking.application.info.endpoint.api.impl.ApplicationInformationApiServiceImpl
             </param-value>
         </init-param>
+        <init-param>
+            <param-name>jaxrs.providers</param-name>
+            <param-value>com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider</param-value>
+        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
 


### PR DESCRIPTION
## Purpose
> Consent manager react app login fails due to a missing dependency in the com.wso2.openbanking.accelerator.application.info.endpoint. This PR adds the missing dependency.

issue: https://github.com/wso2/financial-services-accelerator/issues/860