### PR TITLE
Allow to pass consent metadata to the JSP

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/ExternalAPIConsentRetrievalStep.java
@@ -148,9 +148,6 @@ public class ExternalAPIConsentRetrievalStep implements ConsentRetrievalStep {
                 JSONObject consentDataJSON =
                         new JSONObject(objectMapper.writeValueAsString(responseDTO.getConsentData()));
 
-                // Remove consent metadata
-                consentDataJSON.remove(ConsentAuthorizeConstants.CONSENT_METADATA);
-
                 jsonObject.put(ConsentAuthorizeConstants.CONSENT_DATA, consentDataJSON);
             }
 


### PR DESCRIPTION
## Allow to pass consent metadata to the JSP

> Explain  in a few lines the purpose of this pull request

**Issue link:** https://github.com/wso2/financial-services-accelerator/issues/881

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** OB4

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed consent data handling to preserve metadata in authorization responses. Previously, metadata was being removed from consent data before returning it in API responses. The system now returns complete consent data including all metadata fields, ensuring downstream systems have access to complete information for processing, auditing, and compliance purposes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->