### PR TITLE
Fix issue in consent mapping persistence step

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentPersistStep.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/authorize/impl/DefaultConsentPersistStep.java
@@ -266,8 +266,8 @@ public class DefaultConsentPersistStep implements ConsentPersistStep {
             log.error(ConsentAuthorizeConstants.ACCOUNT_ID_NOT_FOUND_ERROR);
             throw new ConsentException(ResponseStatus.BAD_REQUEST,
                     ConsentAuthorizeConstants.ACCOUNT_ID_NOT_FOUND_ERROR);
-        } else {
-            // in case a consent is denied with no account mappings
+        } else if (!hasAuthorizedAccounts || !isApproved) {
+            // in case a consent is denied or has no account mappings
             accountIDsMapWithPermissions.put("n/a", permissionsDefault);
         }
 


### PR DESCRIPTION
## Fix issue in consent mapping persistence step

> There is an issue in the consent mapping persistence step where an additional record is stored with the account ID set to 'n/a' for each consent mapping.

**Issue link:** [https://github.com/wso2/financial-services-accelerator/issues/885](*https://github.com/wso2/financial-services-accelerator/issues/885*)

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced consent processing to handle edge cases where accounts lack authorization or consent is denied. The system now applies default permissions instead of returning an error, ensuring smoother operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->