### PR TITLE
Updating carbon apimgt version range to support APIM 4.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -655,7 +655,7 @@
         <carbon.identity.local.auth.api.version>2.5.10</carbon.identity.local.auth.api.version>
         <wso2.is7.key.manager.version>2.0.5</wso2.is7.key.manager.version>
         <org.wso2.carbon.apimgt.version>9.30.10</org.wso2.carbon.apimgt.version>
-        <org.wso2.carbon.apimgt.version.range>[9.29.120, 9.32.147)</org.wso2.carbon.apimgt.version.range>
+        <org.wso2.carbon.apimgt.version.range>[9.29.120, 9.33.0)</org.wso2.carbon.apimgt.version.range>
         <!--Unit Test related dependencies-->
         <jacoco.version>0.8.6</jacoco.version>
         <mockito.version>5.3.1</mockito.version>


### PR DESCRIPTION
## Updating carbon apimgt version range to support APIM 4.6.0

> Explain  in a few lines the purpose of this pull request

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/906*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated compatibility range for WSO2 API Manager integration: compatibility upper bound advanced to include newer 9.33.x releases while retaining the existing lower bound.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->