### PR TITLE
Updating consent PUT to allow partial update

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/model/InternalConsentUpdateRequestDTO.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/model/InternalConsentUpdateRequestDTO.java
@@ -21,15 +21,11 @@ package org.wso2.financial.services.accelerator.consent.mgt.extensions.manage.mo
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-
 /**
  * Internal Consent Update Request DTO.
  */
 public class InternalConsentUpdateRequestDTO {
 
-    @NotNull(message = "Consent ID cannot be null")
-    private String consentID;
     private String receipt;
     private String status;
     private Integer consentFrequency;
@@ -37,14 +33,6 @@ public class InternalConsentUpdateRequestDTO {
     private Boolean recurringIndicator;
     private Map<String, String> consentAttributes;
     private List<Authorization> authorizationResources;
-
-    public String getConsentID() {
-        return consentID;
-    }
-
-    public void setConsentID(String consentID) {
-        this.consentID = consentID;
-    }
 
     public String getReceipt() {
         return receipt;

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ConsentManageUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/utils/ConsentManageUtils.java
@@ -330,13 +330,6 @@ public class ConsentManageUtils {
             InternalConsentUpdateRequestDTO updateRequestDTO =  objectMapper.readValue(requestPayload.toString(),
                     InternalConsentUpdateRequestDTO.class);
 
-            if (!updateRequestDTO.getConsentID().equals(consentId)) {
-                log.error("Consent ID in the request body does not match with the consent ID in the " +
-                                "request path");
-                throw new ConsentManagementException("Consent ID in the request body does not match with the " +
-                    "consent ID in the request path");
-            }
-
             String receipt = updateRequestDTO.getReceipt() != null ? updateRequestDTO.getReceipt()
                     : storedConsent.getReceipt();
             String status = updateRequestDTO.getStatus() != null ? updateRequestDTO.getStatus()

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/util/TestConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/util/TestConstants.java
@@ -619,7 +619,6 @@ public class TestConstants {
             "}";
 
     public static final String CONSENT_UPDATE_PAYLOAD = "{\n" +
-            "    \"consentID\": \"" + SAMPLE_CONSENT_ID + "\",\n" +
             "    \"status\": \"authorised\",\n" +
             "    \"validityPeriod\": 0,\n" +
             "    \"recurringIndicator\": true,\n" +


### PR DESCRIPTION
## Updating consent PUT to allow partial update

> This PR updates consent PUT to allow partial update.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/909*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consent update processing now treats several fields as optional/nullable and better handles partial updates; authorization resources and mappings are only applied when provided.
* **Behavior Change**
  * Consent update payload no longer includes a consent ID field.
* **Tests**
  * Update test payloads to remove consent ID from update requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->