### PR TITLE
[Bug Fix] PKCE Properties Not Persisted during Key Generation

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/FSKeyManagerImpl.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/FSKeyManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025 - 2026, WSO2 LLC. (https://www.wso2.com).
  * <p>
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/FSKeyManagerImpl.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/FSKeyManagerImpl.java
@@ -296,6 +296,35 @@ public class FSKeyManagerImpl extends WSO2IS7KeyManager {
             Map<String, Object> spProperties = IdentityServerUtils.constructSPPropertiesList(
                     IdentityServerUtils.getSPMetadataFromSPApp(serviceProviderAppData), additionalProperties);
 
+            // Preserve PKCE and public client settings from the original request. These boolean fields are
+            // unconditionally overwritten by IS when the DCR PUT payload omits them, resetting them to false.
+            // JSON_ADDITIONAL_PROPERTIES may be a HashMap (when oAuthApplicationInfo comes from a parent create/update
+            // response) or a JSON string (when it comes directly from the DevPortal request), so handle both.
+            Object additionalPropsObj = oAuthApplicationInfo.getParameter(APIConstants.JSON_ADDITIONAL_PROPERTIES);
+            if (additionalPropsObj instanceof Map) {
+                Map<?, ?> additionalPropsMap = (Map<?, ?>) additionalPropsObj;
+                for (String pkceKey : new String[]{FSKeyManagerConstants.EXT_PKCE_MANDATORY,
+                        FSKeyManagerConstants.EXT_PKCE_SUPPORT_PLAIN, FSKeyManagerConstants.EXT_PUBLIC_CLIENT}) {
+                    if (additionalPropsMap.containsKey(pkceKey)) {
+                        spProperties.put(pkceKey,
+                                Boolean.parseBoolean(String.valueOf(additionalPropsMap.get(pkceKey))));
+                    }
+                }
+            } else if (additionalPropsObj != null) {
+                try {
+                    JSONObject additionalPropsJson = new JSONObject(additionalPropsObj.toString());
+                    for (String pkceKey : new String[]{FSKeyManagerConstants.EXT_PKCE_MANDATORY,
+                            FSKeyManagerConstants.EXT_PKCE_SUPPORT_PLAIN, FSKeyManagerConstants.EXT_PUBLIC_CLIENT}) {
+                        if (additionalPropsJson.has(pkceKey)) {
+                            spProperties.put(pkceKey,
+                                    Boolean.parseBoolean(additionalPropsJson.get(pkceKey).toString()));
+                        }
+                    }
+                } catch (JSONException e) {
+                    log.warn("Could not extract PKCE properties from additional properties", e);
+                }
+            }
+
             // Update the DCR application
             IdentityServerUtils.updateDCRApplication(super.getKeyManagerConfiguration(),
                     serviceProviderAppData.getString(FSKeyManagerConstants.CLIENT_ID), spAppName, spProperties);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/utils/FSKeyManagerConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/utils/FSKeyManagerConstants.java
@@ -52,5 +52,8 @@ public class FSKeyManagerConstants {
     public static final String TLS_CLIENT_CERT_BOUND_ACCESS_TOKENS = "tls_client_certificate_bound_access_tokens";
     public static final String ADDITIONAL_ATTRIBUTES = "additionalAttributes";
     public static final String ADDITIONAL_SP_PROPERTIES = "additionalSpProperties";
+    public static final String EXT_PKCE_MANDATORY = "ext_pkce_mandatory";
+    public static final String EXT_PKCE_SUPPORT_PLAIN = "ext_pkce_support_plain";
+    public static final String EXT_PUBLIC_CLIENT = "ext_public_client";
 
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/utils/FSKeyManagerConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/utils/FSKeyManagerConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025 - 2026, WSO2 LLC. (https://www.wso2.com).
  * <p>
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/utils/IdentityServerUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/utils/IdentityServerUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025 - 2026, WSO2 LLC. (https://www.wso2.com).
  * <p>
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/utils/IdentityServerUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/main/java/org/wso2/financial/services/accelerator/keymanager/utils/IdentityServerUtils.java
@@ -233,6 +233,15 @@ public class IdentityServerUtils {
             spApplication.put(FSKeyManagerConstants.TLS_CLIENT_CERT_BOUND_ACCESS_TOKENS, true);
         }
 
+        // IS unconditionally overwrites these boolean fields from the PUT body (Java primitive default = false),
+        // so they must always be explicitly included to prevent silent reset to false.
+        spApplication.put(FSKeyManagerConstants.EXT_PKCE_MANDATORY, Boolean.parseBoolean(
+                String.valueOf(attributes.getOrDefault(FSKeyManagerConstants.EXT_PKCE_MANDATORY, false))));
+        spApplication.put(FSKeyManagerConstants.EXT_PKCE_SUPPORT_PLAIN, Boolean.parseBoolean(
+                String.valueOf(attributes.getOrDefault(FSKeyManagerConstants.EXT_PKCE_SUPPORT_PLAIN, false))));
+        spApplication.put(FSKeyManagerConstants.EXT_PUBLIC_CLIENT, Boolean.parseBoolean(
+                String.valueOf(attributes.getOrDefault(FSKeyManagerConstants.EXT_PUBLIC_CLIENT, false))));
+
         return spApplication;
     }
 


### PR DESCRIPTION
## Problem

When generating OAuth keys for the first time from the APIM Developer Portal, additional
properties `ext_pkce_mandatory`, `ext_pkce_support_plain`, and `ext_public_client` were not
preserved — they always reverted to `false` immediately after generation, even though the
correct values were shown in the initial POST `/generate-keys` response.

Subsequent key updates (editing and saving the same properties) worked correctly.

## Root Cause

In `FSKeyManagerImpl.createApplication()`, after `super.createApplication()` correctly
registers the app in IS with the requested PKCE settings, `updateSpProperties()` is called
to persist FS-specific SP metadata. This internally calls `IdentityServerUtils.updateDCRApplication()`,
which performs a `PUT /api/identity/oauth2/dcr/v1.1/register/{clientId}` request. The DCR PUT
payload was missing `ext_pkce_mandatory`, `ext_pkce_support_plain`, and `ext_public_client`.

The WSO2 IS DCR API sets these three fields **unconditionally** from the PUT body — Java
`boolean` primitives default to `false` when absent — so omitting them silently resets all
three to `false`, overwriting what `super.createApplication()` had just set.

This bug also exists in `updateApplication()`, but was masked there because
`super.updateApplication()` is called *after* `updateSpProperties()` and issues its own DCR
PUT that includes the correct values, inadvertently repairing the damage:

| Flow | `updateDCRApplication` (PKCE absent) | `super.create/updateApplication` (PKCE correct) | Final IS state |
|---|---|---|---|
| `createApplication` | runs **2nd** (last) | runs 1st | PKCE = `false` ✗ |
| `updateApplication` | runs **1st** | runs 2nd (last) | PKCE = correct ✓ |

## Fix

- Added three constants to `FSKeyManagerConstants`: `EXT_PKCE_MANDATORY`, `EXT_PKCE_SUPPORT_PLAIN`,
  `EXT_PUBLIC_CLIENT`.
- In `FSKeyManagerImpl.updateSpProperties()`, the three PKCE/public-client values are now extracted
  from `oAuthApplicationInfo` and added to `spProperties` before the DCR PUT call. Both `HashMap`
  (response object from `super.createApplication()`) and JSON `String` (request object in the update
  path) representations are handled.
- In `IdentityServerUtils.constructDCRUpdatePayload()`, the three fields are explicitly included as
  top-level booleans in the PUT payload, preventing IS from resetting them.

## Files Changed

- `FSKeyManagerImpl.java` — extract and forward PKCE values in `updateSpProperties()`
- `IdentityServerUtils.java` — include PKCE fields in `constructDCRUpdatePayload()`
- `FSKeyManagerConstants.java` — add `EXT_PKCE_MANDATORY`, `EXT_PKCE_SUPPORT_PLAIN`, `EXT_PUBLIC_CLIENT` constants

## Testing

1. Create an application in the DevPortal and generate keys with `ext_pkce_mandatory: true`,
   `ext_pkce_support_plain: true`, `ext_public_client: false`.
2. Check whether the fields are correctly ticked in the UI. Also can check the underneath API call `GET /oauth-keys` — confirm the returned `additionalProperties` match what
   was set in step 1 (previously all three returned `false`).
4. Update the keys with changed values — confirm values are correctly persisted after update as well.

Related Issue:

- https://github.com/wso2/financial-services-accelerator/issues/944
