### PR TITLE
[OB3] Fix CXF JSON serialization failure in application info endpoint

### DIFF
--- a/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.accelerator.application.info.endpoint/pom.xml
+++ b/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.accelerator.application.info.endpoint/pom.xml
@@ -34,7 +34,20 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>
-            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
## Issue

Calling `GET /api/openbanking/application/all/metadata` returned the following runtime error:

```
ERROR {org.apache.cxf.jaxrs.utils.JAXRSUtils} - No message body writer has been found for class
com.wso2.open.banking.application.info.endpoint.model.ApplicationBulkMetadataSuccessDTO,
ContentType: application/json
```

## Root Cause

In the application info endpoint `pom.xml`, `swagger-jaxrs` was declared with `<scope>provided</scope>`. This caused its entire transitive dependency subtree — including `jackson-jaxrs-json-provider` — to be excluded from `WEB-INF/lib/`.

At runtime, `CXFNonSpringJaxrsServlet` could not instantiate `com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider` (configured in `web.xml`) because the class was not on the classpath. With no `MessageBodyWriter` registered for `application/json`, CXF failed to serialize the response DTO.

The DCR and PAR endpoints do not have this problem because they declare `swagger-jaxrs` without `provided` scope, which causes `jackson-jaxrs-json-provider` to be bundled transitively.

## Fix

Removed `<scope>provided</scope>` from the `swagger-jaxrs` dependency and added the same exclusions used by DCR and PAR (`jsr311-api`, `guava`, `snakeyaml`) to avoid bundling conflicting artifacts. This allows `jackson-jaxrs-json-provider` to be included in the WAR transitively, consistent with how other endpoints in this project are configured.
