### PR TITLE
[OB4] Add DPoP (RFC 9449) proof-of-possession validation to the Financial Services Gateway

### DIFF
--- a/financial-services-accelerator/accelerators/fs-apim/carbon-home/repository/resources/conf/templates/repository/conf/financial-services.xml.j2
+++ b/financial-services-accelerator/accelerators/fs-apim/carbon-home/repository/resources/conf/templates/repository/conf/financial-services.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  ~
  ~ WSO2 LLC. licenses this file to you under the Apache License,
  ~ Version 2.0 (the "License"); you may not use this file except
@@ -82,9 +82,6 @@
         </DCR>
         <!-- RFC 9449 DPoP-bound access-token validation. Read by DPoPHandler at init(). -->
         <DPoP>
-            {% if financial_services.gateway.dpop.enabled is defined %}
-            <Enabled>{{financial_services.gateway.dpop.enabled}}</Enabled>
-            {% endif %}
             {% if financial_services.gateway.dpop.accepted_algorithms is defined %}
             <AcceptedAlgorithms>{{financial_services.gateway.dpop.accepted_algorithms}}</AcceptedAlgorithms>
             {% endif %}
@@ -102,6 +99,9 @@
             {% endif %}
             {% if financial_services.gateway.dpop.nonce_rotate_after_uses is defined %}
             <NonceRotateAfterUses>{{financial_services.gateway.dpop.nonce_rotate_after_uses}}</NonceRotateAfterUses>
+            {% endif %}
+            {% if financial_services.gateway.dpop.nonce_max_tracked_clients is defined %}
+            <NonceMaxTrackedClients>{{financial_services.gateway.dpop.nonce_max_tracked_clients}}</NonceMaxTrackedClients>
             {% endif %}
             {% if financial_services.gateway.dpop.https_required is defined %}
             <HttpsRequired>{{financial_services.gateway.dpop.https_required}}</HttpsRequired>

--- a/financial-services-accelerator/accelerators/fs-apim/carbon-home/repository/resources/conf/templates/repository/conf/financial-services.xml.j2
+++ b/financial-services-accelerator/accelerators/fs-apim/carbon-home/repository/resources/conf/templates/repository/conf/financial-services.xml.j2
@@ -80,6 +80,42 @@
             <TLSClientCertBoundAccessTokens>true</TLSClientCertBoundAccessTokens>
             {% endif %}
         </DCR>
+        <!-- RFC 9449 DPoP-bound access-token validation. Read by DPoPHandler at init(). -->
+        <DPoP>
+            {% if financial_services.gateway.dpop.enabled is defined %}
+            <Enabled>{{financial_services.gateway.dpop.enabled}}</Enabled>
+            {% endif %}
+            {% if financial_services.gateway.dpop.accepted_algorithms is defined %}
+            <AcceptedAlgorithms>{{financial_services.gateway.dpop.accepted_algorithms}}</AcceptedAlgorithms>
+            {% endif %}
+            {% if financial_services.gateway.dpop.iat_skew_seconds is defined %}
+            <IatSkewSeconds>{{financial_services.gateway.dpop.iat_skew_seconds}}</IatSkewSeconds>
+            {% endif %}
+            {% if financial_services.gateway.dpop.jti_cache_ttl_seconds is defined %}
+            <JtiCacheTtlSeconds>{{financial_services.gateway.dpop.jti_cache_ttl_seconds}}</JtiCacheTtlSeconds>
+            {% endif %}
+            {% if financial_services.gateway.dpop.nonce_strategy is defined %}
+            <NonceStrategy>{{financial_services.gateway.dpop.nonce_strategy}}</NonceStrategy>
+            {% endif %}
+            {% if financial_services.gateway.dpop.nonce_ttl_seconds is defined %}
+            <NonceTtlSeconds>{{financial_services.gateway.dpop.nonce_ttl_seconds}}</NonceTtlSeconds>
+            {% endif %}
+            {% if financial_services.gateway.dpop.nonce_rotate_after_uses is defined %}
+            <NonceRotateAfterUses>{{financial_services.gateway.dpop.nonce_rotate_after_uses}}</NonceRotateAfterUses>
+            {% endif %}
+            {% if financial_services.gateway.dpop.https_required is defined %}
+            <HttpsRequired>{{financial_services.gateway.dpop.https_required}}</HttpsRequired>
+            {% endif %}
+            {% if financial_services.gateway.dpop.strip_dpop_header is defined %}
+            <StripDpopHeader>{{financial_services.gateway.dpop.strip_dpop_header}}</StripDpopHeader>
+            {% endif %}
+            {% if financial_services.gateway.dpop.introspection_cache_ttl_seconds is defined %}
+            <IntrospectionCacheTtlSeconds>{{financial_services.gateway.dpop.introspection_cache_ttl_seconds}}</IntrospectionCacheTtlSeconds>
+            {% endif %}
+            {% if financial_services.gateway.dpop.cache_provider_class is defined %}
+            <CacheProviderClass>{{financial_services.gateway.dpop.cache_provider_class}}</CacheProviderClass>
+            {% endif %}
+        </DPoP>
     </Gateway>
     <KeyManager>
         {% if financial_services.keymanager.extension.impl is defined %}

--- a/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.4.0-deployment.toml
+++ b/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.4.0-deployment.toml
@@ -411,6 +411,21 @@ enable_certificate_chain_validation = true
 [financial_services.gateway.application_registration]
 tls_client_certificate_bound_access_tokens = true
 
+# RFC 9449 DPoP-bound access-token validation
+[financial_services.gateway.dpop]
+enabled = false
+accepted_algorithms = "ES256,ES384,ES512,PS256,PS384,PS512"
+iat_skew_seconds = 60
+jti_cache_ttl_seconds = 120
+nonce_strategy = "never"   # never | always | rotating
+nonce_ttl_seconds = 300
+nonce_rotate_after_uses = 10
+https_required = true
+strip_dpop_header = false
+introspection_cache_ttl_seconds = 60
+# Distributed deployments must point this at a cluster-aware DPoPCacheProvider.
+#cache_provider_class = "com.example.RedisDPoPCacheProvider"
+
 [[financial_services.keymanager.application.type.attributes]]
 name="regulatory"
 label="Regulatory Application"

--- a/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.4.0-deployment.toml
+++ b/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.4.0-deployment.toml
@@ -411,21 +411,6 @@ enable_certificate_chain_validation = true
 [financial_services.gateway.application_registration]
 tls_client_certificate_bound_access_tokens = true
 
-# RFC 9449 DPoP-bound access-token validation
-[financial_services.gateway.dpop]
-enabled = false
-accepted_algorithms = "ES256,ES384,ES512,PS256,PS384,PS512"
-iat_skew_seconds = 60
-jti_cache_ttl_seconds = 120
-nonce_strategy = "never"   # never | always | rotating
-nonce_ttl_seconds = 300
-nonce_rotate_after_uses = 10
-https_required = true
-strip_dpop_header = false
-introspection_cache_ttl_seconds = 60
-# Distributed deployments must point this at a cluster-aware DPoPCacheProvider.
-#cache_provider_class = "com.example.RedisDPoPCacheProvider"
-
 [[financial_services.keymanager.application.type.attributes]]
 name="regulatory"
 label="Regulatory Application"

--- a/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.5.0-deployment.toml
+++ b/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.5.0-deployment.toml
@@ -413,21 +413,6 @@ enable_certificate_chain_validation = true
 [financial_services.gateway.application_registration]
 tls_client_certificate_bound_access_tokens = true
 
-# RFC 9449 DPoP-bound access-token validation
-[financial_services.gateway.dpop]
-enabled = false
-accepted_algorithms = "ES256,ES384,ES512,PS256,PS384,PS512"
-iat_skew_seconds = 60
-jti_cache_ttl_seconds = 120
-nonce_strategy = "never"             # never | always | rotating
-nonce_ttl_seconds = 300
-nonce_rotate_after_uses = 10
-https_required = true
-strip_dpop_header = false
-introspection_cache_ttl_seconds = 60
-# Distributed deployments must point this at a cluster-aware DPoPCacheProvider.
-#cache_provider_class = "com.example.RedisDPoPCacheProvider"
-
 [[financial_services.keymanager.application.type.attributes]]
 name="regulatory"
 label="Regulatory Application"

--- a/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.5.0-deployment.toml
+++ b/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.5.0-deployment.toml
@@ -413,6 +413,21 @@ enable_certificate_chain_validation = true
 [financial_services.gateway.application_registration]
 tls_client_certificate_bound_access_tokens = true
 
+# RFC 9449 DPoP-bound access-token validation
+[financial_services.gateway.dpop]
+enabled = false
+accepted_algorithms = "ES256,ES384,ES512,PS256,PS384,PS512"
+iat_skew_seconds = 60
+jti_cache_ttl_seconds = 120
+nonce_strategy = "never"             # never | always | rotating
+nonce_ttl_seconds = 300
+nonce_rotate_after_uses = 10
+https_required = true
+strip_dpop_header = false
+introspection_cache_ttl_seconds = 60
+# Distributed deployments must point this at a cluster-aware DPoPCacheProvider.
+#cache_provider_class = "com.example.RedisDPoPCacheProvider"
+
 [[financial_services.keymanager.application.type.attributes]]
 name="regulatory"
 label="Regulatory Application"

--- a/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.6.0-deployment.toml
+++ b/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.6.0-deployment.toml
@@ -413,21 +413,6 @@ enable_certificate_chain_validation = true
 [financial_services.gateway.application_registration]
 tls_client_certificate_bound_access_tokens = true
 
-# RFC 9449 DPoP-bound access-token validation
-[financial_services.gateway.dpop]
-enabled = false
-accepted_algorithms = "ES256,ES384,ES512,PS256,PS384,PS512"
-iat_skew_seconds = 60
-jti_cache_ttl_seconds = 120
-nonce_strategy = "never"             # never | always | rotating
-nonce_ttl_seconds = 300
-nonce_rotate_after_uses = 10
-https_required = true
-strip_dpop_header = false
-introspection_cache_ttl_seconds = 60
-# Distributed deployments must point this at a cluster-aware DPoPCacheProvider.
-#cache_provider_class = "com.example.RedisDPoPCacheProvider"
-
 [[financial_services.keymanager.application.type.attributes]]
 name="regulatory"
 label="Regulatory Application"

--- a/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.6.0-deployment.toml
+++ b/financial-services-accelerator/accelerators/fs-apim/repository/resources/wso2am-4.6.0-deployment.toml
@@ -413,6 +413,21 @@ enable_certificate_chain_validation = true
 [financial_services.gateway.application_registration]
 tls_client_certificate_bound_access_tokens = true
 
+# RFC 9449 DPoP-bound access-token validation
+[financial_services.gateway.dpop]
+enabled = false
+accepted_algorithms = "ES256,ES384,ES512,PS256,PS384,PS512"
+iat_skew_seconds = 60
+jti_cache_ttl_seconds = 120
+nonce_strategy = "never"             # never | always | rotating
+nonce_ttl_seconds = 300
+nonce_rotate_after_uses = 10
+https_required = true
+strip_dpop_header = false
+introspection_cache_ttl_seconds = 60
+# Distributed deployments must point this at a cluster-aware DPoPCacheProvider.
+#cache_provider_class = "com.example.RedisDPoPCacheProvider"
+
 [[financial_services.keymanager.application.type.attributes]]
 name="regulatory"
 label="Regulatory Application"

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.common/src/main/java/org/wso2/financial/services/accelerator/common/caching/FinancialServicesBaseCache.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.common/src/main/java/org/wso2/financial/services/accelerator/common/caching/FinancialServicesBaseCache.java
@@ -163,6 +163,45 @@ public abstract class FinancialServicesBaseCache<K extends FinancialServicesBase
     }
 
     /**
+     * Add to cache only if the key is not already present. The check and insert are
+     * performed as a single atomic operation by the underlying JSR-107 provider.
+     * Returns {@code true} if the value was stored, {@code false} if the key already existed.
+     *
+     * @param key    cache key.
+     * @param value  cache value.
+     * @return true if the entry was inserted, false if it already existed.
+     */
+    public boolean addToCacheIfAbsent(K key, V value) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Attempting addIfAbsent for `%s` in cache %s",
+                    key.toString().replaceAll("[\r\n]", ""), cacheName.replaceAll("[\r\n]", "")));
+        }
+
+        return getBaseCache().putIfAbsent(key, value);
+    }
+
+    /**
+     * Remove from cache only if the entry is currently mapped to the expected value.
+     * The check and removal are performed as a single atomic operation by the underlying
+     * JSR-107 provider. Returns {@code true} if the entry was removed, {@code false} if
+     * the key was absent or mapped to a different value.
+     *
+     * @param key            cache key.
+     * @param expectedValue  the value that must be present for the removal to proceed.
+     * @return true if the entry was removed, false otherwise.
+     */
+    public boolean removeFromCacheIfMatch(K key, V expectedValue) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Attempting conditional remove for `%s` in cache %s",
+                    key.toString().replaceAll("[\r\n]", ""), cacheName.replaceAll("[\r\n]", "")));
+        }
+
+        return getBaseCache().remove(key, expectedValue);
+    }
+
+    /**
      * Get Cache for instance.
      *
      * @return Cache instance.

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/pom.xml
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/pom.xml
@@ -66,6 +66,14 @@
             <groupId>org.wso2.financial.services.accelerator</groupId>
             <artifactId>org.wso2.financial.services.accelerator.common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
+        </dependency>
         <!-- Unit Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPConstants.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop;
+
+import static org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants.BEARER_TAG;
+
+/**
+ * RFC 9449 claim names and {@code financial-services.xml} configuration keys
+ * consumed by the DPoP handler.
+ */
+public final class DPoPConstants {
+
+    private DPoPConstants() {
+    }
+
+    public static final String DPOP_HEADER = "DPoP";
+    public static final String DPOP_SCHEME = "DPoP";
+    public static final String DPOP_NONCE_HEADER = "DPoP-Nonce";
+
+    public static final String DPOP_JWT_TYPE = "dpop+jwt";
+    public static final String SHA256_HASH_ALG = "SHA-256";
+
+    public static final int DPOP_SCHEME_LEN = DPOP_SCHEME.length() + 1;
+    public static final int BEARER_SCHEME_LEN = BEARER_TAG.trim().length() + 1;
+
+    public static final String DPOP_BOUND_PROPERTY = "dpop.bound";
+
+    /**
+     * RFC 9449 §4.2 claim names.
+     */
+    public static final class Claims {
+
+        private Claims() {
+        }
+
+        public static final String CNF_CLAIM = "cnf";
+        public static final String JKT_CLAIM = "jkt";
+        public static final String JTI_CLAIM = "jti";
+        public static final String HTM_CLAIM = "htm";
+        public static final String HTU_CLAIM = "htu";
+        public static final String IAT_CLAIM = "iat";
+        public static final String ATH_CLAIM = "ath";
+        public static final String NONCE_CLAIM = "nonce";
+    }
+
+    /**
+     * Flattened keys under {@code <FinancialServices><Gateway><DPoP>...</DPoP></Gateway></FinancialServices>}
+     * as produced by {@code FinancialServicesConfigParser}.
+     */
+    public static final class ConfigKeys {
+
+        private ConfigKeys() {
+        }
+
+        public static final String GATEWAY_DPOP_PREFIX = "Gateway.DPoP.";
+        public static final String ENABLED = GATEWAY_DPOP_PREFIX + "Enabled";
+        public static final String ACCEPTED_ALGORITHMS = GATEWAY_DPOP_PREFIX + "AcceptedAlgorithms";
+        public static final String IAT_SKEW_SECONDS = GATEWAY_DPOP_PREFIX + "IatSkewSeconds";
+        public static final String JTI_CACHE_TTL_SECONDS = GATEWAY_DPOP_PREFIX + "JtiCacheTtlSeconds";
+        public static final String NONCE_STRATEGY = GATEWAY_DPOP_PREFIX + "NonceStrategy";
+        public static final String NONCE_TTL_SECONDS = GATEWAY_DPOP_PREFIX + "NonceTtlSeconds";
+        public static final String NONCE_ROTATE_AFTER_USES = GATEWAY_DPOP_PREFIX + "NonceRotateAfterUses";
+        public static final String HTTPS_REQUIRED = GATEWAY_DPOP_PREFIX + "HttpsRequired";
+        public static final String STRIP_DPOP_HEADER = GATEWAY_DPOP_PREFIX + "StripDpopHeader";
+        public static final String INTROSPECTION_CACHE_TTL_SECONDS =
+                GATEWAY_DPOP_PREFIX + "IntrospectionCacheTtlSeconds";
+        public static final String CACHE_PROVIDER_CLASS = GATEWAY_DPOP_PREFIX + "CacheProviderClass";
+    }
+
+    /**
+     * Default values that apply when a key is absent from {@code financial-services.xml}.
+     */
+    public static final class Defaults {
+
+        private Defaults() {
+        }
+
+        public static final boolean ENABLED = false;
+        public static final String ACCEPTED_ALGORITHMS = "ES256,ES384,ES512,PS256,PS384,PS512";
+        public static final long IAT_SKEW_SECONDS = 60L;
+        public static final long JTI_CACHE_TTL_SECONDS = 120L;
+        public static final String NONCE_STRATEGY = "never";
+        public static final long NONCE_TTL_SECONDS = 300L;
+        public static final int NONCE_ROTATE_AFTER_USES = 10;
+        public static final boolean HTTPS_REQUIRED = true;
+        public static final boolean STRIP_DPOP_HEADER = false;
+        public static final long INTROSPECTION_CACHE_TTL_SECONDS = 60L;
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPConstants.java
@@ -22,7 +22,7 @@ import static org.wso2.financial.services.accelerator.common.constant.FinancialS
 
 /**
  * RFC 9449 claim names and {@code financial-services.xml} configuration keys
- * consumed by the DPoP handler.
+ * consumed by the DPoP module.
  */
 public final class DPoPConstants {
 
@@ -40,6 +40,9 @@ public final class DPoPConstants {
     public static final int BEARER_SCHEME_LEN = BEARER_TAG.trim().length() + 1;
 
     public static final String DPOP_BOUND_PROPERTY = "dpop.bound";
+    /** Synapse message property used to pass a rotated nonce from request to response handling. */
+    public static final String DPOP_RESPONSE_NONCE_PROPERTY = "dpop.response.nonce";
+    public static final String CACHE_CONTROL_NO_STORE = "no-store";
 
     /**
      * RFC 9449 §4.2 claim names.
@@ -69,13 +72,13 @@ public final class DPoPConstants {
         }
 
         public static final String GATEWAY_DPOP_PREFIX = "Gateway.DPoP.";
-        public static final String ENABLED = GATEWAY_DPOP_PREFIX + "Enabled";
         public static final String ACCEPTED_ALGORITHMS = GATEWAY_DPOP_PREFIX + "AcceptedAlgorithms";
         public static final String IAT_SKEW_SECONDS = GATEWAY_DPOP_PREFIX + "IatSkewSeconds";
         public static final String JTI_CACHE_TTL_SECONDS = GATEWAY_DPOP_PREFIX + "JtiCacheTtlSeconds";
         public static final String NONCE_STRATEGY = GATEWAY_DPOP_PREFIX + "NonceStrategy";
         public static final String NONCE_TTL_SECONDS = GATEWAY_DPOP_PREFIX + "NonceTtlSeconds";
         public static final String NONCE_ROTATE_AFTER_USES = GATEWAY_DPOP_PREFIX + "NonceRotateAfterUses";
+        public static final String NONCE_MAX_TRACKED_CLIENTS = GATEWAY_DPOP_PREFIX + "NonceMaxTrackedClients";
         public static final String HTTPS_REQUIRED = GATEWAY_DPOP_PREFIX + "HttpsRequired";
         public static final String STRIP_DPOP_HEADER = GATEWAY_DPOP_PREFIX + "StripDpopHeader";
         public static final String INTROSPECTION_CACHE_TTL_SECONDS =
@@ -91,13 +94,13 @@ public final class DPoPConstants {
         private Defaults() {
         }
 
-        public static final boolean ENABLED = false;
         public static final String ACCEPTED_ALGORITHMS = "ES256,ES384,ES512,PS256,PS384,PS512";
         public static final long IAT_SKEW_SECONDS = 60L;
         public static final long JTI_CACHE_TTL_SECONDS = 120L;
         public static final String NONCE_STRATEGY = "never";
         public static final long NONCE_TTL_SECONDS = 300L;
         public static final int NONCE_ROTATE_AFTER_USES = 10;
+        public static final int NONCE_MAX_TRACKED_CLIENTS = 10_000;
         public static final boolean HTTPS_REQUIRED = true;
         public static final boolean STRIP_DPOP_HEADER = false;
         public static final long INTROSPECTION_CACHE_TTL_SECONDS = 60L;

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPHandler.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop;
+
+import org.apache.axis2.Constants;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.AbstractHandler;
+import org.wso2.financial.services.accelerator.common.logging.Log;
+import org.wso2.financial.services.accelerator.common.logging.LogFactory;
+import org.wso2.financial.services.accelerator.common.util.FinancialServicesUtils;
+import org.wso2.financial.services.accelerator.gateway.dpop.binding.AccessTokenBinder;
+import org.wso2.financial.services.accelerator.gateway.dpop.binding.IntrospectionClient;
+import org.wso2.financial.services.accelerator.gateway.dpop.cache.DPoPCacheProvider;
+import org.wso2.financial.services.accelerator.gateway.dpop.cache.LocalDPoPCacheProvider;
+import org.wso2.financial.services.accelerator.gateway.dpop.nonce.AlwaysNonceStrategy;
+import org.wso2.financial.services.accelerator.gateway.dpop.nonce.NeverNonceStrategy;
+import org.wso2.financial.services.accelerator.gateway.dpop.nonce.NonceStrategy;
+import org.wso2.financial.services.accelerator.gateway.dpop.nonce.RotatingNonceStrategy;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofValidator;
+import org.wso2.financial.services.accelerator.gateway.dpop.util.Challenge;
+import org.wso2.financial.services.accelerator.gateway.dpop.util.DPoPUtils;
+import org.wso2.financial.services.accelerator.gateway.internal.GatewayDataHolder;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants.AUTH_HEADER;
+import static org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants.BEARER_TAG;
+import static org.wso2.financial.services.accelerator.common.util.FinancialServicesUtils.equalsIgnoreCase;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.BEARER_SCHEME_LEN;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_BOUND_PROPERTY;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_HEADER;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_SCHEME;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_SCHEME_LEN;
+
+/**
+ * Custom Synapse handler that validates DPoP-bound access tokens per RFC 9449.
+ * <p>
+ * Must be positioned BEFORE the built-in {@code APIAuthenticationHandler} in
+ * {@code velocity_template.xml}. All tuning is read from {@code financial-services.xml}
+ * under {@code <Gateway><DPoP>...</DPoP></Gateway>}; the only Synapse property
+ * the handler accepts is {@code apiDPoPEnabled}, which lets an API owner opt a single
+ * API out of DPoP enforcement without touching the global config.
+ *
+ * <pre>
+ * &lt;handler class="org.wso2.financial.services.accelerator.gateway.dpop.DPoPHandler"&gt;
+ *     &lt;property name="apiDPoPEnabled" value="true"/&gt;
+ * &lt;/handler&gt;
+ * </pre>
+ */
+public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
+
+    private static final Log log = LogFactory.getLog(DPoPHandler.class);
+
+    // Per-API DPoP enforcement flag — overrides the global setting for a single API
+    private boolean apiDPoPEnabled = true;
+
+    // Resolved at init() from financial-services.xml
+    private boolean globalDPoPEnabled;
+    private long iatSkewSeconds;
+    private long jtiCacheTtlSeconds;
+    private boolean stripDpopHeader;
+    private boolean httpsRequired;
+
+    // Collaborators built once at init()
+    private DPoPProofValidator proofValidator;
+    private NonceStrategy nonceStrategy;
+    private AccessTokenBinder accessTokenBinder;
+    private Challenge challenge;
+    private DPoPCacheProvider cacheProvider;
+
+    @Override
+    public void init(SynapseEnvironment synapseEnvironment) {
+
+        Map<String, Object> cfg = this.readDPopConfig();
+
+        this.globalDPoPEnabled = DPoPUtils.parseBool(cfg.get(DPoPConstants.ConfigKeys.ENABLED),
+                DPoPConstants.Defaults.ENABLED);
+        this.iatSkewSeconds = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.IAT_SKEW_SECONDS),
+                DPoPConstants.Defaults.IAT_SKEW_SECONDS);
+        this.jtiCacheTtlSeconds = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.JTI_CACHE_TTL_SECONDS),
+                DPoPConstants.Defaults.JTI_CACHE_TTL_SECONDS);
+        this.stripDpopHeader = DPoPUtils.parseBool(cfg.get(DPoPConstants.ConfigKeys.STRIP_DPOP_HEADER),
+                DPoPConstants.Defaults.STRIP_DPOP_HEADER);
+        this.httpsRequired = DPoPUtils.parseBool(cfg.get(DPoPConstants.ConfigKeys.HTTPS_REQUIRED),
+                DPoPConstants.Defaults.HTTPS_REQUIRED);
+
+        Set<String> algorithms =
+                DPoPUtils.parseAlgorithms((String) cfg.get(DPoPConstants.ConfigKeys.ACCEPTED_ALGORITHMS));
+        String nonceStrategyName = DPoPUtils.parseString(cfg.get(DPoPConstants.ConfigKeys.NONCE_STRATEGY),
+                DPoPConstants.Defaults.NONCE_STRATEGY);
+        int nonceRotateAfterUses = (int) DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.NONCE_ROTATE_AFTER_USES),
+                DPoPConstants.Defaults.NONCE_ROTATE_AFTER_USES);
+        long introspectionTtl = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.INTROSPECTION_CACHE_TTL_SECONDS),
+                DPoPConstants.Defaults.INTROSPECTION_CACHE_TTL_SECONDS);
+
+        this.proofValidator = new DPoPProofValidator(algorithms, iatSkewSeconds);
+        this.nonceStrategy = buildNonceStrategy(nonceStrategyName, nonceRotateAfterUses);
+        this.accessTokenBinder = new AccessTokenBinder(new IntrospectionClient(introspectionTtl));
+        this.challenge = new Challenge(String.join(" ", algorithms));
+
+        this.cacheProvider = buildCacheProvider(cfg);
+
+        log.info("DPoP handler initialized. globalDPoPEnabled=" + globalDPoPEnabled
+                + ", algorithms=" + algorithms
+                + ", nonceStrategy=" + nonceStrategy.getName()
+                + ", cacheProvider=" + cacheProvider.getClass().getName());
+    }
+
+    @Override
+    public void destroy() {
+        log.info("DPoP handler destroyed.");
+    }
+
+    @Override
+    public boolean handleRequest(MessageContext synCtx) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Handling request in DPoPHandler. " +
+                    "apiDPoPEnabled=" + apiDPoPEnabled + ", globalDPoPEnabled=" + globalDPoPEnabled);
+        }
+        if (!apiDPoPEnabled || !globalDPoPEnabled) {
+            return true;
+        }
+
+        final Map<String, String> headers = DPoPUtils.getTransportHeaders(synCtx);
+        if (headers.isEmpty()) {
+            log.debug("No transport headers found; skipping DPoP validation");
+            return true;
+        }
+
+        final String authHeader = headers.get(AUTH_HEADER);
+        final String dPoPHeader = headers.get(DPOP_HEADER);
+
+        // Declared before try so the catch block can use it without re-parsing the proof JWT.
+        DPoPProofValidator.ParsedProof parsedProof = null;
+
+        try {
+            final boolean isDPoPScheme = authHeader != null
+                    && authHeader.regionMatches(true, 0, DPOP_SCHEME + " ", 0, DPOP_SCHEME_LEN);
+            final boolean isBearerWithDPoP = dPoPHeader != null && authHeader != null
+                    && authHeader.regionMatches(true, 0, BEARER_TAG, 0, BEARER_SCHEME_LEN);
+            String accessToken = DPoPUtils.extractToken(authHeader, isDPoPScheme ? DPOP_SCHEME : BEARER_TAG.trim());
+
+            log.debug(() -> "DPoP handler: scheme=" + (isDPoPScheme ? "DPoP" : "Bearer")
+                    + ", hasDPoPProof=" + (dPoPHeader != null));
+
+            // Parse the proof JWT — kid and JWK thumbprint extracted here are reused
+            // throughout: nonce-cache lookup, full validation, and replay check.
+            if (StringUtils.isNotBlank(dPoPHeader)) {
+                parsedProof = proofValidator.parseDPoPProof(dPoPHeader);
+            }
+
+            // Resolve cnf.jkt — reused for both the early-rejection check below and
+            // the binding verification inside validateDPoP.
+            final String tokenJkt = accessTokenBinder.resolveJkt(accessToken);
+
+            // RFC 9449 §7.1: a DPoP-bound token presented without a proof must be rejected.
+            // For JWT tokens this is detected from claims; for opaque tokens from introspection.
+            if (parsedProof == null && StringUtils.isNotEmpty(tokenJkt)) {
+
+                log.debug(() -> "Rejecting DPoP-bound token presented without a proof: cnf.jkt=" + tokenJkt);
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                        "DPoP proof required for DPoP-bound access token; retry with the proof");
+            }
+
+            if (!isDPoPScheme && !isBearerWithDPoP) {
+                // No DPoP involvement — downstream APIAuthenticationHandler handles the Bearer case
+                log.debug("No DPoP involvement detected; passing request to downstream handler");
+                return true;
+            }
+
+            // RFC 9449 §4.3: exactly one DPoP header field is required
+            if (DPoPUtils.hasMultipleDPopHeaders(synCtx)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "Multiple DPoP headers found");
+            }
+
+            return validateDPoP(synCtx, headers, accessToken, parsedProof, tokenJkt);
+        } catch (DPoPProofException e) {
+
+            log.error("DPoP validation failed. Caused by,", e);
+            // Use the JWK thumbprint from the parsed DPoP proof as the nonce key.
+            final String proofKeyId = parsedProof != null ? parsedProof.getJwkThumbprint() : null;
+            final String nonce = (e.getErrorCode() == DPoPProofException.ErrorCode.USE_DPOP_NONCE && proofKeyId != null)
+                    ? cacheProvider.issueNonce(proofKeyId)
+                    : null;
+            challenge.send401(synCtx, e.getErrorCode(), e.getMessage(), nonce);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean handleResponse(MessageContext synCtx) {
+
+        return true;
+    }
+
+    private boolean validateDPoP(MessageContext synCtx, Map<String, String> headers,
+                                 String accessToken, DPoPProofValidator.ParsedProof parsedProof,
+                                 String tokenJkt) throws DPoPProofException {
+
+        if (parsedProof == null) {
+            // Reached when Authorization: DPoP <token> is present but the DPoP header is missing.
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof required; retry with the proof");
+        }
+
+        final String httpMethod = (String) ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                .getProperty(Constants.Configuration.HTTP_METHOD);
+        final String htu = DPoPUtils.normalizeHtu(synCtx, headers);
+
+        if (httpsRequired) {
+            DPoPUtils.checkHttps(htu);
+        }
+
+        // JWK thumbprint is derived from actual key material — preferred over the
+        // client-controlled kid field as the nonce cache key.
+        final String proofJwkThumbprint = parsedProof.getJwkThumbprint();
+
+        log.debug(() -> "Validating DPoP proof: method=" + httpMethod + ", htu=" + htu
+                + ", kid=" + parsedProof.getKid() + ", proofKeyId=" + proofJwkThumbprint);
+
+        // 1. Nonce check — if nonce is required but absent or expired, reject immediately.
+        //    The catch block in handleRequest issues the nonce and includes it in the 401
+        //    response for both the "no active nonce" and "nonce mismatch" cases, so no
+        //    issueNonce call is made here.
+        String expectedNonce = null;
+        if (proofJwkThumbprint != null && nonceStrategy.requiresNonce(proofJwkThumbprint)) {
+            expectedNonce = cacheProvider.getActiveNonce(proofJwkThumbprint);
+            if (expectedNonce == null) {
+
+                log.debug(() -> "No active nonce for proofKeyId=" + proofJwkThumbprint + "; challenging client");
+                throw new DPoPProofException(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                        "DPoP-Nonce required; retry with the issued nonce");
+            }
+            log.debug(() -> "Nonce check: active nonce found for proofKeyId=" + proofJwkThumbprint);
+        }
+
+        // 2. Validate proof JWT (signature, header, claims, ath)
+        DPoPProofValidator.ValidationResult result =
+                proofValidator.validate(parsedProof, httpMethod, htu, accessToken, expectedNonce);
+        final String proofJkt = result.getProofJkt();
+
+        // 3. Replay defense — jti comes from the validation result.
+        final String jti = result.getJti();
+        log.debug(() -> "Checking jti replay: jti=" + jti);
+
+        if (jti == null || !cacheProvider.isJtiFirstUse(jti, proofJkt, jtiCacheTtlSeconds)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof jti has already been used (replay detected)");
+        }
+
+        // 4. Token binding — use the resolved tokenJkt
+        accessTokenBinder.verifyBinding(tokenJkt, proofJkt);
+
+        // 5. Consume the nonce (if used)
+        if (expectedNonce != null) {
+            cacheProvider.isNonceValidAndConsumed(proofJwkThumbprint, expectedNonce);
+        }
+
+        // 6. Rewrite Authorization: DPoP <token> → Authorization: Bearer <token>
+        //    so the downstream OAuthAuthenticator works unchanged. Remove any case-variant
+        //    of the key first, then write with the canonical case the authenticator expects.
+        DPoPUtils.removeHeader(headers, AUTH_HEADER);
+        headers.put(AUTH_HEADER, BEARER_TAG + accessToken);
+        if (stripDpopHeader) {
+            DPoPUtils.removeHeader(headers, DPOP_HEADER);
+        }
+        ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                .setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, headers);
+
+        synCtx.setProperty(DPOP_BOUND_PROPERTY, Boolean.TRUE);
+        log.debug(() -> "DPoP validation successful for request: " + htu);
+
+        return true;
+    }
+
+    private Map<String, Object> readDPopConfig() {
+        if (GatewayDataHolder.getInstance().getFinancialServicesConfigurationService() == null) {
+            log.warn("FinancialServicesConfigurationService not available; DPoP handler will use defaults");
+            return Collections.emptyMap();
+        }
+        Map<String, Object> all = GatewayDataHolder.getInstance()
+                .getFinancialServicesConfigurationService().getConfigurations();
+        return all == null ? Collections.emptyMap() : all;
+    }
+
+    /**
+     * Resolves the configured {@link DPoPCacheProvider} (default {@link LocalDPoPCacheProvider})
+     * and hands it every {@code Gateway.DPoP.*} key with the prefix stripped, so a custom
+     * impl (e.g. Redis) can read its own backend-specific keys directly from the map
+     * without coupling the SPI to any particular backend.
+     */
+    private DPoPCacheProvider buildCacheProvider(Map<String, Object> cfg) {
+        final String fqn = (String) cfg.get(DPoPConstants.ConfigKeys.CACHE_PROVIDER_CLASS);
+        DPoPCacheProvider provider;
+        if (StringUtils.isBlank(fqn)) {
+            provider = new LocalDPoPCacheProvider();
+        } else {
+            provider = FinancialServicesUtils.getClassInstanceFromFQN(fqn, DPoPCacheProvider.class);
+            if (provider == null) {
+                throw new IllegalStateException("Configured " + DPoPConstants.ConfigKeys.CACHE_PROVIDER_CLASS
+                        + " = '" + fqn + "' could not be instantiated as a " + DPoPCacheProvider.class.getName());
+            }
+        }
+        provider.initialize(collectDPoPProperties(cfg));
+        return provider;
+    }
+
+    private Map<String, Object> collectDPoPProperties(Map<String, Object> cfg) {
+        Map<String, Object> sub = new HashMap<>();
+        final String prefix = DPoPConstants.ConfigKeys.GATEWAY_DPOP_PREFIX;
+        for (Map.Entry<String, Object> e : cfg.entrySet()) {
+            if (e.getKey().startsWith(prefix)) {
+                sub.put(e.getKey().substring(prefix.length()), e.getValue());
+            }
+        }
+        return sub;
+    }
+
+    private NonceStrategy buildNonceStrategy(String name, int rotateAfterUses) {
+        if (equalsIgnoreCase("always", name)) {
+            return new AlwaysNonceStrategy();
+        } else if (equalsIgnoreCase("rotating", name)) {
+            return new RotatingNonceStrategy(rotateAfterUses);
+        }
+        return new NeverNonceStrategy();
+    }
+
+    /**
+     * Synapse property setter for the per-API DPoP enforcement toggle.
+     * Set {@code value="false"} on the handler element to opt a single API out of
+     * DPoP enforcement without touching the global configuration.
+     */
+    public void setApiDPoPEnabled(String apiDPoPEnabled) {
+        this.apiDPoPEnabled = Boolean.parseBoolean(apiDPoPEnabled);
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPHandler.java
@@ -20,6 +20,7 @@ package org.wso2.financial.services.accelerator.gateway.dpop;
 
 import org.apache.axis2.Constants;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
 import org.apache.synapse.ManagedLifecycle;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.core.SynapseEnvironment;
@@ -32,10 +33,8 @@ import org.wso2.financial.services.accelerator.gateway.dpop.binding.AccessTokenB
 import org.wso2.financial.services.accelerator.gateway.dpop.binding.IntrospectionClient;
 import org.wso2.financial.services.accelerator.gateway.dpop.cache.DPoPCacheProvider;
 import org.wso2.financial.services.accelerator.gateway.dpop.cache.LocalDPoPCacheProvider;
-import org.wso2.financial.services.accelerator.gateway.dpop.nonce.AlwaysNonceStrategy;
-import org.wso2.financial.services.accelerator.gateway.dpop.nonce.NeverNonceStrategy;
 import org.wso2.financial.services.accelerator.gateway.dpop.nonce.NonceStrategy;
-import org.wso2.financial.services.accelerator.gateway.dpop.nonce.RotatingNonceStrategy;
+import org.wso2.financial.services.accelerator.gateway.dpop.nonce.NonceStrategyType;
 import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
 import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofValidator;
 import org.wso2.financial.services.accelerator.gateway.dpop.util.Challenge;
@@ -49,10 +48,12 @@ import java.util.Set;
 
 import static org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants.AUTH_HEADER;
 import static org.wso2.financial.services.accelerator.common.constant.FinancialServicesConstants.BEARER_TAG;
-import static org.wso2.financial.services.accelerator.common.util.FinancialServicesUtils.equalsIgnoreCase;
 import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.BEARER_SCHEME_LEN;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.CACHE_CONTROL_NO_STORE;
 import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_BOUND_PROPERTY;
 import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_HEADER;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_NONCE_HEADER;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_RESPONSE_NONCE_PROPERTY;
 import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_SCHEME;
 import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_SCHEME_LEN;
 
@@ -61,9 +62,8 @@ import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants
  * <p>
  * Must be positioned BEFORE the built-in {@code APIAuthenticationHandler} in
  * {@code velocity_template.xml}. All tuning is read from {@code financial-services.xml}
- * under {@code <Gateway><DPoP>...</DPoP></Gateway>}; the only Synapse property
- * the handler accepts is {@code apiDPoPEnabled}, which lets an API owner opt a single
- * API out of DPoP enforcement without touching the global config.
+ * under {@code <Gateway><DPoP>...</DPoP></Gateway>}. DPoP enforcement is opt-in per API:
+ * set {@code apiDPoPEnabled=true} on each handler element that requires it.
  *
  * <pre>
  * &lt;handler class="org.wso2.financial.services.accelerator.gateway.dpop.DPoPHandler"&gt;
@@ -75,11 +75,10 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
 
     private static final Log log = LogFactory.getLog(DPoPHandler.class);
 
-    // Per-API DPoP enforcement flag — overrides the global setting for a single API
-    private boolean apiDPoPEnabled = true;
+    // DPoP enforcement is opt-in per API; set value="true" on the handler element to enable.
+    private boolean apiDPoPEnabled = false;
 
     // Resolved at init() from financial-services.xml
-    private boolean globalDPoPEnabled;
     private long iatSkewSeconds;
     private long jtiCacheTtlSeconds;
     private boolean stripDpopHeader;
@@ -97,8 +96,6 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
 
         Map<String, Object> cfg = this.readDPopConfig();
 
-        this.globalDPoPEnabled = DPoPUtils.parseBool(cfg.get(DPoPConstants.ConfigKeys.ENABLED),
-                DPoPConstants.Defaults.ENABLED);
         this.iatSkewSeconds = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.IAT_SKEW_SECONDS),
                 DPoPConstants.Defaults.IAT_SKEW_SECONDS);
         this.jtiCacheTtlSeconds = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.JTI_CACHE_TTL_SECONDS),
@@ -114,18 +111,20 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
                 DPoPConstants.Defaults.NONCE_STRATEGY);
         int nonceRotateAfterUses = (int) DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.NONCE_ROTATE_AFTER_USES),
                 DPoPConstants.Defaults.NONCE_ROTATE_AFTER_USES);
+        int nonceMaxTrackedClients = (int) DPoPUtils.parseLong(
+                cfg.get(DPoPConstants.ConfigKeys.NONCE_MAX_TRACKED_CLIENTS),
+                DPoPConstants.Defaults.NONCE_MAX_TRACKED_CLIENTS);
         long introspectionTtl = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.INTROSPECTION_CACHE_TTL_SECONDS),
                 DPoPConstants.Defaults.INTROSPECTION_CACHE_TTL_SECONDS);
 
         this.proofValidator = new DPoPProofValidator(algorithms, iatSkewSeconds);
-        this.nonceStrategy = buildNonceStrategy(nonceStrategyName, nonceRotateAfterUses);
+        this.nonceStrategy = this.buildNonceStrategy(nonceStrategyName, nonceRotateAfterUses, nonceMaxTrackedClients);
         this.accessTokenBinder = new AccessTokenBinder(new IntrospectionClient(introspectionTtl));
         this.challenge = new Challenge(String.join(" ", algorithms));
 
         this.cacheProvider = buildCacheProvider(cfg);
 
-        log.info("DPoP handler initialized. globalDPoPEnabled=" + globalDPoPEnabled
-                + ", algorithms=" + algorithms
+        log.info("DPoP handler initialized. algorithms=" + algorithms
                 + ", nonceStrategy=" + nonceStrategy.getName()
                 + ", cacheProvider=" + cacheProvider.getClass().getName());
     }
@@ -139,10 +138,9 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
     public boolean handleRequest(MessageContext synCtx) {
 
         if (log.isDebugEnabled()) {
-            log.debug("Handling request in DPoPHandler. " +
-                    "apiDPoPEnabled=" + apiDPoPEnabled + ", globalDPoPEnabled=" + globalDPoPEnabled);
+            log.debug("Handling request in DPoPHandler. apiDPoPEnabled=" + apiDPoPEnabled);
         }
-        if (!apiDPoPEnabled || !globalDPoPEnabled) {
+        if (!apiDPoPEnabled) {
             return true;
         }
 
@@ -216,6 +214,16 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
     @Override
     public boolean handleResponse(MessageContext synCtx) {
 
+        final boolean isDPoPBound = DPoPUtils.parseBool(synCtx.getProperty(DPOP_BOUND_PROPERTY), false);
+        final String rotatedNonce = (String) synCtx.getProperty(DPOP_RESPONSE_NONCE_PROPERTY);
+        if (isDPoPBound && rotatedNonce != null) {
+            Map<String, String> headers = DPoPUtils.getTransportHeaders(synCtx);
+            headers.put(DPOP_NONCE_HEADER, rotatedNonce);
+            // RFC 9449 §8.2: responses that carry a nonce must not be cached.
+            headers.put(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_NO_STORE);
+            ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                    .setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, headers);
+        }
         return true;
     }
 
@@ -244,20 +252,22 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
         log.debug(() -> "Validating DPoP proof: method=" + httpMethod + ", htu=" + htu
                 + ", kid=" + parsedProof.getKid() + ", proofKeyId=" + proofJwkThumbprint);
 
-        // 1. Nonce check — if nonce is required but absent or expired, reject immediately.
-        //    The catch block in handleRequest issues the nonce and includes it in the 401
-        //    response for both the "no active nonce" and "nonce mismatch" cases, so no
-        //    issueNonce call is made here.
-        String expectedNonce = null;
-        if (proofJwkThumbprint != null && nonceStrategy.requiresNonce(proofJwkThumbprint)) {
-            expectedNonce = cacheProvider.getActiveNonce(proofJwkThumbprint);
-            if (expectedNonce == null) {
+        // 1. Nonce check — RFC 9449 §11.3: must reject proofs without nonce whenever one
+        //    has been issued to this client, even between strategy rotation points.
+        boolean strategyRequiresNonce = proofJwkThumbprint != null
+                && nonceStrategy.requiresNonce(proofJwkThumbprint);
+        String activeNonce = proofJwkThumbprint != null
+                ? cacheProvider.getActiveNonce(proofJwkThumbprint) : null;
 
+        String expectedNonce = null;
+        if (strategyRequiresNonce || activeNonce != null) {
+            if (activeNonce == null) {
                 log.debug(() -> "No active nonce for proofKeyId=" + proofJwkThumbprint + "; challenging client");
                 throw new DPoPProofException(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
                         "DPoP-Nonce required; retry with the issued nonce");
             }
-            log.debug(() -> "Nonce check: active nonce found for proofKeyId=" + proofJwkThumbprint);
+            expectedNonce = activeNonce;
+            log.debug(() -> "Nonce check required for proofKeyId=" + proofJwkThumbprint);
         }
 
         // 2. Validate proof JWT (signature, header, claims, ath)
@@ -277,9 +287,11 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
         // 4. Token binding — use the resolved tokenJkt
         accessTokenBinder.verifyBinding(tokenJkt, proofJkt);
 
-        // 5. Consume the nonce (if used)
-        if (expectedNonce != null) {
-            cacheProvider.isNonceValidAndConsumed(proofJwkThumbprint, expectedNonce);
+        // 5. Rotation — if strategy says rotate, issue fresh nonce and deliver on 200 response (RFC 9449 §8.2).
+        if (proofJwkThumbprint != null && nonceStrategy.shouldRotate(proofJwkThumbprint)) {
+            String rotatedNonce = cacheProvider.issueNonce(proofJwkThumbprint);
+            synCtx.setProperty(DPOP_RESPONSE_NONCE_PROPERTY, rotatedNonce);
+            log.debug(() -> "Nonce rotated for proofKeyId=" + proofJwkThumbprint);
         }
 
         // 6. Rewrite Authorization: DPoP <token> → Authorization: Bearer <token>
@@ -342,19 +354,26 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
         return sub;
     }
 
-    private NonceStrategy buildNonceStrategy(String name, int rotateAfterUses) {
-        if (equalsIgnoreCase("always", name)) {
-            return new AlwaysNonceStrategy();
-        } else if (equalsIgnoreCase("rotating", name)) {
-            return new RotatingNonceStrategy(rotateAfterUses);
+    /**
+     * Maps the configured nonce strategy name to its implementation.
+     * Falls back to {@code never} for unrecognised names.
+     */
+    private NonceStrategy buildNonceStrategy(String name, int rotateAfterUses, int maxTrackedClients) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Building nonce strategy: name=%s, rotateAfterUses=%s, maxTrackedClients=%s",
+                    name, rotateAfterUses, maxTrackedClients));
         }
-        return new NeverNonceStrategy();
+        return NonceStrategyType.fromName(name)
+                .orElseGet(() -> {
+                    log.warn("Unsupported DPoP nonce strategy '" + name + "' - falling back to 'never'.");
+                    return NonceStrategyType.NEVER;
+                }).create(rotateAfterUses, maxTrackedClients);
     }
 
     /**
      * Synapse property setter for the per-API DPoP enforcement toggle.
-     * Set {@code value="false"} on the handler element to opt a single API out of
-     * DPoP enforcement without touching the global configuration.
+     * Set {@code value="true"} on the handler element to enable DPoP enforcement for an API.
      */
     public void setApiDPoPEnabled(String apiDPoPEnabled) {
         this.apiDPoPEnabled = Boolean.parseBoolean(apiDPoPEnabled);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/AccessTokenBinder.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/AccessTokenBinder.java
@@ -98,6 +98,15 @@ public class AccessTokenBinder {
 
     }
 
+    /**
+     * Resolves {@code cnf.jkt} for an opaque access token by calling the Key Manager
+     * introspection endpoint. Results are cached by {@link IntrospectionClient} for the
+     * configured TTL to avoid repeated round-trips for the same token.
+     *
+     * @param accessToken raw opaque access token
+     * @return the {@code cnf.jkt} JWK thumbprint, or {@code null} if the token has no DPoP binding
+     * @throws DPoPProofException if the introspection call fails
+     */
     private String extractJktViaIntrospection(String accessToken) throws DPoPProofException {
         try {
             return introspectionClient.getJwkThumbprint(accessToken);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/AccessTokenBinder.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/AccessTokenBinder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.binding;
+
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.financial.services.accelerator.common.logging.Log;
+import org.wso2.financial.services.accelerator.common.logging.LogFactory;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
+import org.wso2.financial.services.accelerator.gateway.dpop.util.DPoPUtils;
+
+/**
+ * Resolves {@code cnf.jkt} from the access token and verifies it against the
+ * computed JWK thumbprint from the DPoP proof.
+ * <ul>
+ *   <li>JWT access tokens: {@code cnf.jkt} is read directly from the JWT claims
+ *       (no signature verification — that is the downstream OAuth authenticator's job).</li>
+ *   <li>Opaque access tokens: {@code cnf.jkt} is obtained via Key Manager introspection;
+ *       results are cached by {@link IntrospectionClient} for the configured TTL so
+ *       repeated calls for the same token within that window avoid extra network calls.</li>
+ * </ul>
+ */
+public class AccessTokenBinder {
+
+    private static final Log log = LogFactory.getLog(AccessTokenBinder.class);
+
+    private final IntrospectionClient introspectionClient;
+
+    public AccessTokenBinder(IntrospectionClient introspectionClient) {
+
+        this.introspectionClient = introspectionClient;
+    }
+
+    /**
+     * Resolves {@code cnf.jkt} from the access token regardless of its format.
+     * <p>
+     * Callers should invoke this once per request and pass the result to
+     * {@link #verifyBinding(String, String)}, so that resolution — whether a
+     * local JWT parse or a remote introspection call.
+     *
+     * @param accessToken raw access token string; {@code null} or blank returns {@code null}
+     * @return the JWK thumbprint, or {@code null} if the token carries no DPoP binding
+     * @throws DPoPProofException if the token is malformed or introspection fails
+     */
+    public String resolveJkt(String accessToken) throws DPoPProofException {
+
+        if (StringUtils.isBlank(accessToken)) {
+            return null;
+        }
+        final boolean isJwt = DPoPUtils.isJwtToken(accessToken);
+        log.debug(() -> "Resolving cnf.jkt from " + (isJwt ? "JWT" : "opaque") + " access token");
+
+        final String jkt = isJwt ? DPoPUtils.extractJktFromJwt(accessToken) : extractJktViaIntrospection(accessToken);
+        log.debug(() -> "Resolved cnf.jkt: " + (StringUtils.isNotBlank(jkt) ? jkt : "<none: token is not DPoP-bound>"));
+
+        return jkt;
+    }
+
+    /**
+     * Verifies that the pre-resolved JWK thumbprint from the access token matches
+     * the thumbprint computed from the DPoP proof's public key.
+     * <p>
+     * Accepts the already-resolved {@code tokenJkt} (from {@link #resolveJkt}) so
+     * that JWT parsing and introspection are never repeated for the same request.
+     *
+     * @param tokenJkt JWK thumbprint resolved from the access token (may be {@code null})
+     * @param proofJkt JWK thumbprint computed from the validated DPoP proof
+     * @throws DPoPProofException if the token has no DPoP binding or the thumbprints mismatch
+     */
+    public void verifyBinding(String tokenJkt, String proofJkt) throws DPoPProofException {
+        if (StringUtils.isBlank(tokenJkt)) {
+            // Per RFC 9449 §7.1: a token presented under the DPoP scheme must have cnf.jkt.
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                    "Access token presented under DPoP scheme has no cnf.jkt binding");
+        }
+        if (!tokenJkt.equals(proofJkt)) {
+
+            log.debug(() -> "cnf.jkt mismatch: token=" + tokenJkt + ", proof=" + proofJkt);
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                    "DPoP proof public key thumbprint does not match the access token's cnf.jkt");
+        }
+        log.debug(() -> "DPoP token binding verified: cnf.jkt=" + tokenJkt);
+
+    }
+
+    private String extractJktViaIntrospection(String accessToken) throws DPoPProofException {
+        try {
+            return introspectionClient.getJwkThumbprint(accessToken);
+        } catch (IntrospectionClient.IntrospectionException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                    "Failed to obtain cnf.jkt from token introspection: " + e.getMessage(), e);
+        }
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/IntrospectionClient.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/IntrospectionClient.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.binding;
+
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
+import org.wso2.carbon.apimgt.api.model.KeyManager;
+import org.wso2.carbon.apimgt.impl.dto.KeyManagerDto;
+import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.financial.services.accelerator.common.logging.Log;
+import org.wso2.financial.services.accelerator.common.logging.LogFactory;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.SHA256_HASH_ALG;
+
+/**
+ * Wraps the APIM Key Manager introspection endpoint to retrieve {@code cnf.jkt}
+ * for opaque tokens. Results are cached keyed by a SHA-256 hash of the raw token
+ * to avoid repeated round-trips for the same token within its validity window.
+ */
+public class IntrospectionClient {
+
+    private static final Log log = LogFactory.getLog(IntrospectionClient.class);
+
+    private final long cacheTtlMs;
+    private final ConcurrentHashMap<String, CachedEntry> introspectionCache = new ConcurrentHashMap<>();
+
+    public IntrospectionClient(long cacheTtlSeconds) {
+        this.cacheTtlMs = cacheTtlSeconds * 1000L;
+    }
+
+    /**
+     * Returns the {@code cnf.jkt} from token introspection, or {@code null} if the
+     * token has no DPoP binding.
+     *
+     * @param accessToken raw opaque access token
+     * @throws IntrospectionException if the introspection call fails
+     */
+    public String getJwkThumbprint(String accessToken) throws IntrospectionException {
+        String cacheKey = hashToken(accessToken);
+        CachedEntry cached = introspectionCache.get(cacheKey);
+        if (cached != null && !cached.isExpired()) {
+            return cached.jkt;
+        }
+        final String jkt = introspect(accessToken);
+        if (StringUtils.isNotBlank(jkt)) {
+            // putIfAbsent ensures that if two threads both see a cache miss and both call
+            // introspect(), only the first result is stored. The second thread's result is
+            // discarded silently — both return the same jkt since introspection is deterministic.
+            introspectionCache.putIfAbsent(cacheKey,
+                    new CachedEntry(jkt, System.currentTimeMillis() + cacheTtlMs));
+        }
+        return jkt;
+    }
+
+    private String introspect(String accessToken) throws IntrospectionException {
+        try {
+            final String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .getTenantDomain(true);
+            Map<String, KeyManagerDto> keyManagerDtoMap = KeyManagerHolder.getTenantKeyManagers(tenantDomain);
+            if (keyManagerDtoMap == null || keyManagerDtoMap.isEmpty()) {
+                throw new IntrospectionException("No key manager configured for tenant: " + tenantDomain);
+            }
+            for (Map.Entry<String, KeyManagerDto> entry : keyManagerDtoMap.entrySet()) {
+                KeyManager keyManager = entry.getValue().getKeyManager();
+                if (keyManager == null) {
+                    continue;
+                }
+                try {
+                    AccessTokenInfo tokenInfo = keyManager.getTokenMetaData(accessToken);
+                    if (tokenInfo == null || !tokenInfo.isTokenValid()) {
+                        continue;
+                    }
+                    Object cnf = tokenInfo.getParameter(DPoPConstants.Claims.CNF_CLAIM);
+                    if (cnf instanceof Map) {
+                        @SuppressWarnings("unchecked")
+                        Object jkt = ((Map<String, Object>) cnf).get(DPoPConstants.Claims.JKT_CLAIM);
+                        return jkt != null ? jkt.toString() : null;
+                    }
+                    return null;
+                } catch (APIManagementException e) {
+                    log.debug("Key manager " + entry.getKey()
+                            + " failed to introspect token, trying next: " + e.getMessage());
+                }
+            }
+            throw new IntrospectionException("Token introspection failed for all configured key managers");
+        } catch (IntrospectionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IntrospectionException("Unexpected error during token introspection: " + e.getMessage(), e);
+        }
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest md = MessageDigest.getInstance(SHA256_HASH_ALG);
+            byte[] hash = md.digest(token.getBytes(StandardCharsets.US_ASCII));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            log.debug("SHA-256 algorithm not available for token hashing, falling back to hashCode", e);
+            return String.valueOf(token.hashCode());
+        }
+    }
+
+    private static final class CachedEntry {
+
+        final String jkt;
+        final long expiresAt;
+
+        CachedEntry(String jkt, long expiresAt) {
+            this.jkt = jkt;
+            this.expiresAt = expiresAt;
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() > expiresAt;
+        }
+    }
+
+    /**
+     * Thrown when the upstream introspection endpoint cannot resolve a token.
+     */
+    public static class IntrospectionException extends Exception {
+
+        private static final long serialVersionUID = 87452349823745L;
+
+        public IntrospectionException(String message) {
+            super(message);
+        }
+
+        public IntrospectionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/IntrospectionClient.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/IntrospectionClient.java
@@ -67,53 +67,59 @@ public class IntrospectionClient {
         if (cached != null && !cached.isExpired()) {
             return cached.jkt;
         }
+        if (cached != null) {
+            // Remove the stale entry so putIfAbsent below can store the fresh result.
+            // Using the value-matched overload is safe under concurrent updates: if another
+            // thread already replaced this entry, remove() is a no-op.
+            introspectionCache.remove(cacheKey, cached);
+        }
         final String jkt = introspect(accessToken);
         if (StringUtils.isNotBlank(jkt)) {
-            // putIfAbsent ensures that if two threads both see a cache miss and both call
-            // introspect(), only the first result is stored. The second thread's result is
-            // discarded silently — both return the same jkt since introspection is deterministic.
+            // putIfAbsent: if two threads race here, the first writer wins and the second
+            // result is silently discarded — both return the same jkt (introspection is deterministic).
             introspectionCache.putIfAbsent(cacheKey,
                     new CachedEntry(jkt, System.currentTimeMillis() + cacheTtlMs));
         }
         return jkt;
     }
 
+    /**
+     * Iterates over all Key Managers configured for the current tenant and returns
+     * the first {@code cnf.jkt} found for the given token.
+     *
+     * @param accessToken raw opaque access token
+     * @return the {@code cnf.jkt} JWK thumbprint, or {@code null} if the token has no DPoP binding
+     * @throws IntrospectionException if all Key Managers fail or none are configured
+     */
     private String introspect(String accessToken) throws IntrospectionException {
-        try {
-            final String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                    .getTenantDomain(true);
-            Map<String, KeyManagerDto> keyManagerDtoMap = KeyManagerHolder.getTenantKeyManagers(tenantDomain);
-            if (keyManagerDtoMap == null || keyManagerDtoMap.isEmpty()) {
-                throw new IntrospectionException("No key manager configured for tenant: " + tenantDomain);
+        final String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(true);
+        Map<String, KeyManagerDto> keyManagerDtoMap = KeyManagerHolder.getTenantKeyManagers(tenantDomain);
+        if (keyManagerDtoMap == null || keyManagerDtoMap.isEmpty()) {
+            throw new IntrospectionException("No key manager configured for tenant: " + tenantDomain);
+        }
+        for (Map.Entry<String, KeyManagerDto> entry : keyManagerDtoMap.entrySet()) {
+            KeyManager keyManager = entry.getValue().getKeyManager();
+            if (keyManager == null) {
+                continue;
             }
-            for (Map.Entry<String, KeyManagerDto> entry : keyManagerDtoMap.entrySet()) {
-                KeyManager keyManager = entry.getValue().getKeyManager();
-                if (keyManager == null) {
+            try {
+                AccessTokenInfo tokenInfo = keyManager.getTokenMetaData(accessToken);
+                if (tokenInfo == null || !tokenInfo.isTokenValid()) {
                     continue;
                 }
-                try {
-                    AccessTokenInfo tokenInfo = keyManager.getTokenMetaData(accessToken);
-                    if (tokenInfo == null || !tokenInfo.isTokenValid()) {
-                        continue;
-                    }
-                    Object cnf = tokenInfo.getParameter(DPoPConstants.Claims.CNF_CLAIM);
-                    if (cnf instanceof Map) {
-                        @SuppressWarnings("unchecked")
-                        Object jkt = ((Map<String, Object>) cnf).get(DPoPConstants.Claims.JKT_CLAIM);
-                        return jkt != null ? jkt.toString() : null;
-                    }
-                    return null;
-                } catch (APIManagementException e) {
-                    log.debug("Key manager " + entry.getKey()
-                            + " failed to introspect token, trying next: " + e.getMessage());
+                Object cnf = tokenInfo.getParameter(DPoPConstants.Claims.CNF_CLAIM);
+                if (cnf instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Object jkt = ((Map<String, Object>) cnf).get(DPoPConstants.Claims.JKT_CLAIM);
+                    return jkt != null ? jkt.toString() : null;
                 }
+                return null;
+            } catch (APIManagementException e) {
+                log.error("Key manager " + entry.getKey()
+                        + " failed to introspect token, trying next: " + e.getMessage(), e);
             }
-            throw new IntrospectionException("Token introspection failed for all configured key managers");
-        } catch (IntrospectionException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new IntrospectionException("Unexpected error during token introspection: " + e.getMessage(), e);
         }
+        throw new IntrospectionException("Token introspection failed for all configured key managers");
     }
 
     private String hashToken(String token) {

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPCacheKey.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPCacheKey.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.cache;
+
+import org.wso2.financial.services.accelerator.common.caching.FinancialServicesBaseCacheKey;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Cache key for DPoP JTI replay-defense and nonce caches.
+ */
+public class DPoPCacheKey extends FinancialServicesBaseCacheKey implements Serializable {
+
+    private static final long serialVersionUID = 6823941170341530021L;
+    private final String dPoPCacheKey;
+
+    public DPoPCacheKey(String dPoPCacheKey) {
+
+        this.dPoPCacheKey = dPoPCacheKey;
+    }
+
+    public static DPoPCacheKey of(String dPoPCacheKey) {
+
+        return new DPoPCacheKey(dPoPCacheKey);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DPoPCacheKey that = (DPoPCacheKey) o;
+        return Objects.equals(dPoPCacheKey, that.dPoPCacheKey);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(dPoPCacheKey);
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPCacheProvider.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPCacheProvider.java
@@ -32,8 +32,8 @@ import java.util.Map;
  * routed to a different node would not be detected.
  * <p>
  * Implementations must be safe for concurrent use by multiple gateway worker threads.
- * Both {@link #isJtiFirstUse} and {@link #isNonceValidAndConsumed} must be atomic;
- * a partial overlap between the read and write is not acceptable.
+ * {@link #isJtiFirstUse} must be atomic; a partial overlap between the read and write
+ * is not acceptable.
  */
 public interface DPoPCacheProvider {
 
@@ -72,15 +72,4 @@ public interface DPoPCacheProvider {
      * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key
      */
     String getActiveNonce(String proofKeyId);
-
-    /**
-     * Atomically verifies that {@code submittedNonce} matches the active nonce for
-     * {@code proofKeyId} and removes it if so (single-use). Returns {@code true} only if
-     * the nonce matched and was successfully consumed. Returns {@code false} if the nonce
-     * was absent, already consumed, or did not match — all of which must be treated as
-     * an invalid request.
-     *
-     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key
-     */
-    boolean isNonceValidAndConsumed(String proofKeyId, String submittedNonce);
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPCacheProvider.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPCacheProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.cache;
+
+import java.util.Map;
+
+/**
+ * SPI for the two pieces of state the DPoP handler maintains: the JTI replay-defense
+ * set (per RFC 9449 §11.1) and the per-client nonce store (per §8).
+ * <p>
+ * The default implementation {@link LocalDPoPCacheProvider} uses the gateway's
+ * node-local Carbon javax.cache and is sufficient for single-node deployments.
+ * Distributed deployments must provide their own implementation (e.g. Redis-backed)
+ * via {@code Gateway.DPoP.CacheProviderClass} in {@code financial-services.xml},
+ * because a node-local seen-set is racy across cluster members — a replayed proof
+ * routed to a different node would not be detected.
+ * <p>
+ * Implementations must be safe for concurrent use by multiple gateway worker threads.
+ * Both {@link #isJtiFirstUse} and {@link #isNonceValidAndConsumed} must be atomic;
+ * a partial overlap between the read and write is not acceptable.
+ */
+public interface DPoPCacheProvider {
+
+    /**
+     * Called once at handler init. The map contains every {@code Gateway.DPoP.*} key
+     * declared in {@code financial-services.xml}, stripped of the {@code Gateway.DPoP.}
+     * prefix, so an implementation can read its own backend-specific keys (e.g.
+     * {@code Cache.Redis.Host}) without coupling the SPI to any particular backend.
+     */
+    void initialize(Map<String, Object> properties);
+
+    /**
+     * Atomically checks whether the {@code (jti, jkt)} pair has been seen before and
+     * records it if not. Returns {@code true} if this is the first occurrence of the pair
+     * (the proof is fresh and has been recorded), {@code false} if it was already present
+     * (the proof is a replay and must be rejected).
+     *
+     * @param jti        the {@code jti} claim from the DPoP proof
+     * @param jkt        the SHA-256 JWK thumbprint of the proof's public key (sender scope)
+     * @param ttlSeconds how long the entry must remain in the cache
+     */
+    boolean isJtiFirstUse(String jti, String jkt, long ttlSeconds);
+
+    /**
+     * Generates a fresh nonce, stores it against {@code proofKeyId} (replacing any prior
+     * value), and returns it. The TTL is determined by the implementation's configuration
+     * set at {@link #initialize} time.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key
+     */
+    String issueNonce(String proofKeyId);
+
+    /**
+     * Returns the currently active nonce for {@code proofKeyId}, or {@code null} if none.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key
+     */
+    String getActiveNonce(String proofKeyId);
+
+    /**
+     * Atomically verifies that {@code submittedNonce} matches the active nonce for
+     * {@code proofKeyId} and removes it if so (single-use). Returns {@code true} only if
+     * the nonce matched and was successfully consumed. Returns {@code false} if the nonce
+     * was absent, already consumed, or did not match — all of which must be treated as
+     * an invalid request.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key
+     */
+    boolean isNonceValidAndConsumed(String proofKeyId, String submittedNonce);
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPJtiCache.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPJtiCache.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.cache;
+
+import org.wso2.financial.services.accelerator.common.caching.FinancialServicesBaseCache;
+
+/**
+ * Cache for DPoP proof JTI replay defense (RFC 9449 §11.1).
+ * Records each seen {@code (jti, jkt)} pair and rejects duplicates.
+ */
+public class DPoPJtiCache extends FinancialServicesBaseCache<DPoPCacheKey, String> {
+
+    private static final String CACHE_NAME = "FINANCIAL_SERVICES_DPOP_JTI_CACHE";
+
+    private final Integer accessExpiryMinutes;
+    private final Integer modifiedExpiryMinutes;
+
+    public DPoPJtiCache(long ttlSeconds) {
+
+        super(CACHE_NAME);
+        int minutes = Math.max(1, (int) Math.ceil((double) ttlSeconds / 60));
+        this.accessExpiryMinutes = minutes;
+        this.modifiedExpiryMinutes = minutes;
+    }
+
+    /**
+     * Atomically checks whether the {@code (jti, jkt)} pair is new and records it if so.
+     *
+     * @param jti the {@code jti} claim from the DPoP proof.
+     * @param jkt the SHA-256 JWK thumbprint of the proof's public key.
+     * @return true if this is the first use of the pair, false if it is a replay.
+     */
+    public boolean isJtiFirstUse(String jti, String jkt) {
+
+        return addToCacheIfAbsent(DPoPCacheKey.of(jti + ":" + jkt), Boolean.TRUE.toString());
+    }
+
+    @Override
+    public int getCacheAccessExpiryMinutes() {
+
+        return accessExpiryMinutes;
+    }
+
+    @Override
+    public int getCacheModifiedExpiryMinutes() {
+
+        return modifiedExpiryMinutes;
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPNonceCache.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPNonceCache.java
@@ -22,7 +22,7 @@ import org.wso2.financial.services.accelerator.common.caching.FinancialServicesB
 
 /**
  * Cache for DPoP nonce storage (RFC 9449 §8).
- * Maintains the active nonce per client and supports single-use consumption.
+ * Maintains the active nonce per client; nonces are reusable until the server rotates them.
  */
 public class DPoPNonceCache extends FinancialServicesBaseCache<DPoPCacheKey, String> {
 
@@ -59,19 +59,6 @@ public class DPoPNonceCache extends FinancialServicesBaseCache<DPoPCacheKey, Str
     public String getActiveNonce(String proofKeyId) {
 
         return getFromCache(DPoPCacheKey.of(proofKeyId));
-    }
-
-    /**
-     * Atomically verifies that the submitted nonce matches the active nonce and removes it if so.
-     * Returns {@code true} only if the match and removal both succeeded.
-     *
-     * @param proofKeyId     the nonce cache key, typically the JWK thumbprint of the proof's public key.
-     * @param submittedNonce the nonce value presented by the client.
-     * @return {@code true} if the nonce was valid and consumed, {@code false} otherwise.
-     */
-    public boolean isNonceValidAndConsumed(String proofKeyId, String submittedNonce) {
-
-        return removeFromCacheIfMatch(DPoPCacheKey.of(proofKeyId), submittedNonce);
     }
 
     @Override

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPNonceCache.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/DPoPNonceCache.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.cache;
+
+import org.wso2.financial.services.accelerator.common.caching.FinancialServicesBaseCache;
+
+/**
+ * Cache for DPoP nonce storage (RFC 9449 §8).
+ * Maintains the active nonce per client and supports single-use consumption.
+ */
+public class DPoPNonceCache extends FinancialServicesBaseCache<DPoPCacheKey, String> {
+
+    private static final String CACHE_NAME = "FINANCIAL_SERVICES_DPOP_NONCE_CACHE";
+
+    private final Integer accessExpiryMinutes;
+    private final Integer modifiedExpiryMinutes;
+
+    public DPoPNonceCache(long ttlSeconds) {
+
+        super(CACHE_NAME);
+        int minutes = Math.max(1, (int) Math.ceil((double) ttlSeconds / 60));
+        this.accessExpiryMinutes = minutes;
+        this.modifiedExpiryMinutes = minutes;
+    }
+
+    /**
+     * Stores the nonce for the given key, replacing any previously active nonce.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key.
+     * @param nonce      the nonce value to store.
+     */
+    public void storeNonce(String proofKeyId, String nonce) {
+
+        addToCache(DPoPCacheKey.of(proofKeyId), nonce);
+    }
+
+    /**
+     * Returns the currently active nonce for the given key, or {@code null} if none exists.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key.
+     * @return the active nonce, or {@code null}.
+     */
+    public String getActiveNonce(String proofKeyId) {
+
+        return getFromCache(DPoPCacheKey.of(proofKeyId));
+    }
+
+    /**
+     * Atomically verifies that the submitted nonce matches the active nonce and removes it if so.
+     * Returns {@code true} only if the match and removal both succeeded.
+     *
+     * @param proofKeyId     the nonce cache key, typically the JWK thumbprint of the proof's public key.
+     * @param submittedNonce the nonce value presented by the client.
+     * @return {@code true} if the nonce was valid and consumed, {@code false} otherwise.
+     */
+    public boolean isNonceValidAndConsumed(String proofKeyId, String submittedNonce) {
+
+        return removeFromCacheIfMatch(DPoPCacheKey.of(proofKeyId), submittedNonce);
+    }
+
+    @Override
+    public int getCacheAccessExpiryMinutes() {
+
+        return accessExpiryMinutes;
+    }
+
+    @Override
+    public int getCacheModifiedExpiryMinutes() {
+
+        return modifiedExpiryMinutes;
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/LocalDPoPCacheProvider.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/LocalDPoPCacheProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.cache;
+
+import org.wso2.financial.services.accelerator.common.logging.Log;
+import org.wso2.financial.services.accelerator.common.logging.LogFactory;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.wso2.financial.services.accelerator.gateway.dpop.util.DPoPUtils.parseLong;
+
+/**
+ * Default {@link DPoPCacheProvider} backed by the gateway's node-local
+ * {@code FinancialServicesBaseCache} infrastructure. Suitable for single-node deployments.
+ * Distributed gateway deployments require a cluster-aware implementation since the JTI
+ * seen-set and nonce store are not replicated across nodes — a replayed proof or a reused
+ * nonce routed to a different node would not be detected.
+ */
+public class LocalDPoPCacheProvider implements DPoPCacheProvider {
+
+    private static final Log log = LogFactory.getLog(LocalDPoPCacheProvider.class);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private DPoPJtiCache jtiCache;
+    private DPoPNonceCache nonceCache;
+
+    @Override
+    public void initialize(Map<String, Object> properties) {
+
+        long jtiTtl = parseLong(properties.get("JtiCacheTtlSeconds"),
+                DPoPConstants.Defaults.JTI_CACHE_TTL_SECONDS);
+        long nonceTtl = parseLong(properties.get("NonceTtlSeconds"),
+                DPoPConstants.Defaults.NONCE_TTL_SECONDS);
+
+        this.jtiCache = new DPoPJtiCache(jtiTtl);
+        this.nonceCache = new DPoPNonceCache(nonceTtl);
+
+        if (log.isDebugEnabled()) {
+            log.debug("LocalDPoPCacheProvider initialized. jtiTtlSeconds=" + jtiTtl
+                    + ", nonceTtlSeconds=" + nonceTtl);
+        }
+    }
+
+    /**
+     * {@code ttlSeconds} is consumed at initialization; this parameter is ignored per call.
+     */
+    @Override
+    public boolean isJtiFirstUse(String jti, String jkt, long ttlSeconds) {
+
+        return jtiCache.isJtiFirstUse(jti, jkt);
+    }
+
+    /**
+     * Generates a cryptographically random nonce, stores it against {@code proofKeyId}
+     * replacing any prior value, and returns it to be sent in the {@code DPoP-Nonce}
+     * response header.
+     */
+    @Override
+    public String issueNonce(String proofKeyId) {
+
+        String nonce = generateNonce();
+        nonceCache.storeNonce(proofKeyId, nonce);
+        return nonce;
+    }
+
+    /**
+     * Returns the currently active nonce for {@code proofKeyId}, or {@code null} if none
+     * has been issued yet.
+     */
+    @Override
+    public String getActiveNonce(String proofKeyId) {
+
+        return nonceCache.getActiveNonce(proofKeyId);
+    }
+
+    /**
+     * Atomically verifies and consumes the nonce. Returns {@code false} immediately if
+     * {@code submittedNonce} is {@code null}.
+     */
+    @Override
+    public boolean isNonceValidAndConsumed(String proofKeyId, String submittedNonce) {
+
+        if (submittedNonce == null) {
+            return false;
+        }
+        return nonceCache.isNonceValidAndConsumed(proofKeyId, submittedNonce);
+    }
+
+    private String generateNonce() {
+
+        byte[] bytes = new byte[16];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/LocalDPoPCacheProvider.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/LocalDPoPCacheProvider.java
@@ -92,19 +92,6 @@ public class LocalDPoPCacheProvider implements DPoPCacheProvider {
         return nonceCache.getActiveNonce(proofKeyId);
     }
 
-    /**
-     * Atomically verifies and consumes the nonce. Returns {@code false} immediately if
-     * {@code submittedNonce} is {@code null}.
-     */
-    @Override
-    public boolean isNonceValidAndConsumed(String proofKeyId, String submittedNonce) {
-
-        if (submittedNonce == null) {
-            return false;
-        }
-        return nonceCache.isNonceValidAndConsumed(proofKeyId, submittedNonce);
-    }
-
     private String generateNonce() {
 
         byte[] bytes = new byte[16];

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/AlwaysNonceStrategy.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/AlwaysNonceStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.nonce;
+
+/**
+ * Always requires a DPoP-Nonce on every request.
+ */
+public class AlwaysNonceStrategy implements NonceStrategy {
+
+    @Override
+    public boolean requiresNonce(String clientIdentity) {
+
+        return true;
+    }
+
+    @Override
+    public String getName() {
+
+        return "always";
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/AlwaysNonceStrategy.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/AlwaysNonceStrategy.java
@@ -30,6 +30,12 @@ public class AlwaysNonceStrategy implements NonceStrategy {
     }
 
     @Override
+    public boolean shouldRotate(String clientIdentity) {
+        // Nonce is reused until the TTL expires; rotation is driven by expiry, not by use-count.
+        return false;
+    }
+
+    @Override
     public String getName() {
 
         return "always";

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NeverNonceStrategy.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NeverNonceStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.nonce;
+
+/**
+ * Never requires a DPoP-Nonce. Default strategy — lowest client friction.
+ */
+public class NeverNonceStrategy implements NonceStrategy {
+
+    @Override
+    public boolean requiresNonce(String clientIdentity) {
+
+        return false;
+    }
+
+    @Override
+    public String getName() {
+
+        return "never";
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NeverNonceStrategy.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NeverNonceStrategy.java
@@ -30,6 +30,12 @@ public class NeverNonceStrategy implements NonceStrategy {
     }
 
     @Override
+    public boolean shouldRotate(String clientIdentity) {
+
+        return false;
+    }
+
+    @Override
     public String getName() {
 
         return "never";

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategy.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategy.java
@@ -19,15 +19,23 @@
 package org.wso2.financial.services.accelerator.gateway.dpop.nonce;
 
 /**
- * Strategy interface deciding whether a DPoP-Nonce is required for a given client.
- * Client identity is normally the JWK thumbprint of the proof's public key.
+ * Strategy interface deciding whether a DPoP-Nonce is required for a given client
+ * and when to rotate it. Client identity is normally the JWK thumbprint of the proof's public key.
  */
 public interface NonceStrategy {
 
     /**
-     * Returns {@code true} if the handler must demand a nonce from this client.
+     * Pure policy check — returns {@code true} if this strategy requires nonces at all.
+     * Must be side-effect-free; the handler calls it on every request.
      */
     boolean requiresNonce(String clientIdentity);
+
+    /**
+     * Called once after each successful proof validation. Returns {@code true} when the
+     * strategy decides the current nonce should be rotated (i.e. a fresh nonce should be
+     * issued and delivered in the {@code 200} response per RFC 9449 §8.2).
+     */
+    boolean shouldRotate(String clientIdentity);
 
     /**
      * Returns the strategy name used in {@code financial-services.xml}.

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategy.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.nonce;
+
+/**
+ * Strategy interface deciding whether a DPoP-Nonce is required for a given client.
+ * Client identity is normally the JWK thumbprint of the proof's public key.
+ */
+public interface NonceStrategy {
+
+    /**
+     * Returns {@code true} if the handler must demand a nonce from this client.
+     */
+    boolean requiresNonce(String clientIdentity);
+
+    /**
+     * Returns the strategy name used in {@code financial-services.xml}.
+     */
+    String getName();
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategyType.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategyType.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.nonce;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * Registry of built-in {@link NonceStrategy} implementations. Each constant owns its
+ * factory so that adding a new strategy requires touching only this file.
+ */
+public enum NonceStrategyType {
+
+    NEVER("never", (uses, cap) -> new NeverNonceStrategy()),
+    ALWAYS("always", (uses, cap) -> new AlwaysNonceStrategy()),
+    ROTATING("rotating", RotatingNonceStrategy::new);
+
+    private final String configKey;
+    private final BiFunction<Integer, Integer, NonceStrategy> factory;
+
+    NonceStrategyType(String configKey, BiFunction<Integer, Integer, NonceStrategy> factory) {
+
+        this.configKey = configKey;
+        this.factory = factory;
+    }
+
+    /**
+     * Instantiates the strategy with the supplied rotation parameters.
+     * Strategies that do not use these parameters simply ignore them.
+     */
+    public NonceStrategy create(int rotateAfterUses, int maxTrackedClients) {
+
+        return factory.apply(rotateAfterUses, maxTrackedClients);
+    }
+
+    /**
+     * Looks up a {@link NonceStrategyType} by its config-file key (case-insensitive).
+     * Returns {@link Optional#empty()} for unrecognised names — the caller decides
+     * whether to warn and fall back or to fail fast.
+     */
+    public static Optional<NonceStrategyType> fromName(String name) {
+
+        if (name == null) {
+            return Optional.empty();
+        }
+        final String normalised = name.toLowerCase(Locale.ROOT);
+        return Arrays.stream(values())
+                .filter(t -> t.configKey.equals(normalised))
+                .findFirst();
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/RotatingNonceStrategy.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/RotatingNonceStrategy.java
@@ -24,44 +24,54 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Rotates nonces after a configurable number of uses per client identity. Requires
- * a nonce on the first request from a client, then every {@code rotateAfterUses}
- * subsequent successful proof validations.
+ * Rotates the nonce every {@code rotateAfterUses} successful proof validations per client.
+ * The nonce is reused between rotations; a fresh nonce is delivered proactively in the
+ * {@code 200} response (RFC 9449 §8.2) so the client never pays an extra round-trip.
  */
 public class RotatingNonceStrategy implements NonceStrategy {
 
-    private static final int MAX_TRACKED_CLIENTS = 10_000;
-
     private final int rotateAfterUses;
-    // Access-ordered LRU map — evicts the least-recently-seen client identity once the
-    // cap is reached, preventing unbounded growth for long-running gateway instances.
-    private final Map<String, AtomicLong> useCounts = Collections.synchronizedMap(
-            new LinkedHashMap<String, AtomicLong>(MAX_TRACKED_CLIENTS, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<String, AtomicLong> eldest) {
-                    return size() > MAX_TRACKED_CLIENTS;
-                }
-            });
+    private final int maxTrackedClients;
+    // Access-ordered LRU map — evicts the least-recently-seen client identity once the cap is reached.
+    private final Map<String, AtomicLong> useCounts;
 
-    public RotatingNonceStrategy(int rotateAfterUses) {
+    public RotatingNonceStrategy(int rotateAfterUses, int maxTrackedClients) {
 
         this.rotateAfterUses = Math.max(1, rotateAfterUses);
+        this.maxTrackedClients = Math.max(1, maxTrackedClients);
+        this.useCounts = Collections.synchronizedMap(
+                new LinkedHashMap<String, AtomicLong>(this.maxTrackedClients, 0.75f, true) {
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<String, AtomicLong> eldest) {
+                        return size() > RotatingNonceStrategy.this.maxTrackedClients;
+                    }
+                });
     }
 
     /**
-     * Returns {@code true} on the first call for a given identity and on every
-     * {@code rotateAfterUses}-th subsequent call. Increments the use counter on each
-     * invocation — must not be called more than once per request.
+     * Pure policy check — always returns {@code true} because once a nonce is issued to a
+     * client it must be required on every subsequent request (RFC 9449 §11.3). First-issue
+     * is handled by the {@code activeNonce == null} path in the handler, not here.
      */
     @Override
     public boolean requiresNonce(String clientIdentity) {
+
+        return true;
+    }
+
+    /**
+     * Increments the per-client use counter and returns {@code true} every
+     * {@code rotateAfterUses}-th call, triggering proactive nonce rotation.
+     */
+    @Override
+    public boolean shouldRotate(String clientIdentity) {
 
         AtomicLong counter;
         synchronized (useCounts) {
             counter = useCounts.computeIfAbsent(clientIdentity, k -> new AtomicLong(0));
         }
         long count = counter.incrementAndGet();
-        return count == 1 || (count % rotateAfterUses == 0);
+        return count % rotateAfterUses == 0;
     }
 
     @Override

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/RotatingNonceStrategy.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/RotatingNonceStrategy.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.nonce;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Rotates nonces after a configurable number of uses per client identity. Requires
+ * a nonce on the first request from a client, then every {@code rotateAfterUses}
+ * subsequent successful proof validations.
+ */
+public class RotatingNonceStrategy implements NonceStrategy {
+
+    private static final int MAX_TRACKED_CLIENTS = 10_000;
+
+    private final int rotateAfterUses;
+    // Access-ordered LRU map — evicts the least-recently-seen client identity once the
+    // cap is reached, preventing unbounded growth for long-running gateway instances.
+    private final Map<String, AtomicLong> useCounts = Collections.synchronizedMap(
+            new LinkedHashMap<String, AtomicLong>(MAX_TRACKED_CLIENTS, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, AtomicLong> eldest) {
+                    return size() > MAX_TRACKED_CLIENTS;
+                }
+            });
+
+    public RotatingNonceStrategy(int rotateAfterUses) {
+
+        this.rotateAfterUses = Math.max(1, rotateAfterUses);
+    }
+
+    /**
+     * Returns {@code true} on the first call for a given identity and on every
+     * {@code rotateAfterUses}-th subsequent call. Increments the use counter on each
+     * invocation — must not be called more than once per request.
+     */
+    @Override
+    public boolean requiresNonce(String clientIdentity) {
+
+        AtomicLong counter;
+        synchronized (useCounts) {
+            counter = useCounts.computeIfAbsent(clientIdentity, k -> new AtomicLong(0));
+        }
+        long count = counter.incrementAndGet();
+        return count == 1 || (count % rotateAfterUses == 0);
+    }
+
+    @Override
+    public String getName() {
+
+        return "rotating";
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/proof/DPoPProofException.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/proof/DPoPProofException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.proof;
+
+/**
+ * Signals a DPoP proof validation failure per RFC 9449. Carries the RFC-defined
+ * error code used in the {@code WWW-Authenticate} challenge sent back to clients.
+ */
+public class DPoPProofException extends Exception {
+
+    private static final long serialVersionUID = 8473629184756L;
+
+    /**
+     * RFC 9449 §7.1 error codes returned in the challenge.
+     */
+    public enum ErrorCode {
+
+        /**
+         * The DPoP proof JWT itself failed validation (§4.3).
+         */
+        INVALID_DPOP_PROOF("invalid_dpop_proof"),
+
+        /**
+         * The access token is invalid or the DPoP binding check failed.
+         */
+        INVALID_TOKEN("invalid_token"),
+
+        /**
+         * The server requires a DPoP-Nonce and none was supplied or it was stale.
+         */
+        USE_DPOP_NONCE("use_dpop_nonce");
+
+        private final String value;
+
+        ErrorCode(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    private final ErrorCode errorCode;
+
+    public DPoPProofException(ErrorCode errorCode, String message) {
+
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public DPoPProofException(ErrorCode errorCode, String message, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+
+        return errorCode;
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/proof/DPoPProofValidator.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/proof/DPoPProofValidator.java
@@ -207,9 +207,18 @@ public class DPoPProofValidator {
         return new ValidationResult(computeJwkThumbprint(jwk), claims.getJWTID());
     }
 
+    /**
+     * Validates the DPoP proof JOSE header per RFC 9449 §4.3 rules 4–7:
+     * {@code typ} must be {@code dpop+jwt}, {@code alg} must be asymmetric and in the
+     * accepted list, {@code jwk} must be present and must not contain private key material.
+     *
+     * @param header the JWS header of the parsed proof JWT
+     * @return the public JWK embedded in the header
+     * @throws DPoPProofException if any header constraint is violated
+     */
     private JWK validateHeader(JWSHeader header) throws DPoPProofException {
         // RFC 9449 §4.3 rule 4: typ must be "dpop+jwt"
-        if (header.getType() == null || !equalsIgnoreCase(DPOP_JWT_TYPE, header.getType().getType())) {
+        if (header.getType() == null || !equalsIgnoreCase(DPOP_JWT_TYPE, (header.getType().getType()))) {
             throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
                     "DPoP proof typ must be \"dpop+jwt\", got: " + header.getType());
         }
@@ -239,6 +248,13 @@ public class DPoPProofValidator {
         return jwk;
     }
 
+    /**
+     * Verifies the DPoP proof signature against the public key embedded in its header.
+     *
+     * @param signedJWT the parsed proof JWT
+     * @param jwk       the public key extracted from the proof header
+     * @throws DPoPProofException if signature verification fails or the JWK type is unsupported
+     */
     private void verifySignature(SignedJWT signedJWT, JWK jwk) throws DPoPProofException {
         try {
             JWSVerifier verifier = buildVerifier(jwk);
@@ -252,6 +268,14 @@ public class DPoPProofValidator {
         }
     }
 
+    /**
+     * Constructs a {@link JWSVerifier} for the given JWK key type (RSA, EC, or OKP/Ed25519).
+     *
+     * @param jwk the public key from the proof header
+     * @return a verifier suitable for the key type
+     * @throws JOSEException      if the key material cannot be parsed
+     * @throws DPoPProofException if the key type or OKP curve is unsupported
+     */
     private JWSVerifier buildVerifier(JWK jwk) throws JOSEException, DPoPProofException {
         KeyType keyType = jwk.getKeyType();
         if (KeyType.RSA.equals(keyType)) {
@@ -270,6 +294,13 @@ public class DPoPProofValidator {
                 "Unsupported JWK key type: " + keyType);
     }
 
+    /**
+     * Extracts the JWT claims set from the signed JWT.
+     *
+     * @param signedJWT the parsed and signature-verified proof JWT
+     * @return the claims set
+     * @throws DPoPProofException if the claims payload cannot be parsed
+     */
     private JWTClaimsSet parseClaims(SignedJWT signedJWT) throws DPoPProofException {
 
         try {
@@ -280,6 +311,20 @@ public class DPoPProofValidator {
         }
     }
 
+    /**
+     * Validates proof claims per RFC 9449 §4.3 rules 8–12:
+     * {@code htm} must match the request method, {@code htu} must match the normalized
+     * request URI, {@code iat} must be within the skew window, {@code ath} must equal
+     * the access token hash when a token is present, and {@code nonce} must match the
+     * server-issued nonce when one is required.
+     *
+     * @param claims        the claims set from the proof JWT
+     * @param requestHtm    HTTP method of the current request
+     * @param requestHtu    normalized request URI (no query or fragment)
+     * @param accessToken   raw access token for {@code ath} verification, or {@code null}
+     * @param expectedNonce server-issued nonce to match, or {@code null} if not required
+     * @throws DPoPProofException if any claim constraint is violated
+     */
     private void validateClaims(JWTClaimsSet claims, String requestHtm, String requestHtu,
                                 String accessToken, String expectedNonce) throws DPoPProofException {
 
@@ -352,6 +397,14 @@ public class DPoPProofValidator {
         }
     }
 
+    /**
+     * Computes the {@code ath} claim value as {@code base64url(SHA-256(ASCII(accessToken)))}
+     * per RFC 9449 §4.2.
+     *
+     * @param accessToken raw access token string
+     * @return base64url-encoded SHA-256 hash of the ASCII-encoded token
+     * @throws DPoPProofException if the SHA-256 algorithm is unavailable on this JVM
+     */
     private String computeAth(String accessToken) throws DPoPProofException {
         try {
             MessageDigest digest = MessageDigest.getInstance(SHA256_HASH_ALG);
@@ -363,6 +416,14 @@ public class DPoPProofValidator {
         }
     }
 
+    /**
+     * Returns {@code true} if {@code a} and {@code b} are equal after stripping trailing
+     * slashes and ignoring case, following the URI normalization requirements of RFC 9449 §4.3.
+     *
+     * @param a first URI string, may be {@code null}
+     * @param b second URI string, may be {@code null}
+     * @return {@code true} if the normalized URIs are equal; {@code false} if either is {@code null}
+     */
     private boolean normalizedUriEquals(String a, String b) {
         if (a == null || b == null) {
             return false;
@@ -370,10 +431,24 @@ public class DPoPProofValidator {
         return equalsIgnoreCase(stripTrailingSlash(a), stripTrailingSlash(b));
     }
 
+    /**
+     * Removes a trailing {@code /} from {@code uri} if present.
+     *
+     * @param uri URI string to normalize
+     * @return the URI without a trailing slash
+     */
     private String stripTrailingSlash(String uri) {
         return uri.endsWith("/") ? uri.substring(0, uri.length() - 1) : uri;
     }
 
+    /**
+     * Strips the query string and fragment from {@code url}, returning only
+     * {@code scheme://authority/path} for htu claim comparison per RFC 9449 §4.3 rule 9.
+     *
+     * @param url the raw htu claim value from the proof
+     * @return normalized URI without query or fragment, or {@code null} if {@code url} is blank
+     * @throws DPoPProofException if {@code url} has invalid URI syntax
+     */
     private String removeQueryAndFragment(String url) throws DPoPProofException {
         try {
             if (StringUtils.isBlank(url)) {

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/proof/DPoPProofValidator.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/proof/DPoPProofValidator.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.proof;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.Ed25519Verifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.ThumbprintUtils;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.financial.services.accelerator.common.logging.Log;
+import org.wso2.financial.services.accelerator.common.logging.LogFactory;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Set;
+
+import static org.wso2.financial.services.accelerator.common.util.FinancialServicesUtils.equalsIgnoreCase;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_JWT_TYPE;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.SHA256_HASH_ALG;
+
+/**
+ * Pure JOSE proof validation per RFC 9449 §4.2 and §4.3. Has no Synapse or APIM
+ * runtime dependencies; safe to unit-test in isolation.
+ * <p>
+ * Usage: construct once with the desired algorithm allow-list and clock skew,
+ * then call {@link #validate} once per request.
+ */
+public class DPoPProofValidator {
+
+    private static final Log log = LogFactory.getLog(DPoPProofValidator.class);
+
+    private final Set<String> acceptedAlgorithms;
+    private final long iatSkewMillis;
+
+    public DPoPProofValidator(Set<String> acceptedAlgorithms, long iatSkewSeconds) {
+
+        this.acceptedAlgorithms = acceptedAlgorithms;
+        this.iatSkewMillis = iatSkewSeconds * 1000L;
+    }
+
+    /**
+     * Lightweight result of the initial proof JWT parse. Holds the data needed before
+     * full validation — the JWK thumbprint for nonce-cache lookup and the {@code kid}
+     * for logging. Pass to {@link #validate} to complete the cryptographic checks.
+     */
+    public static final class ParsedProof {
+
+        private final SignedJWT signedJWT;
+        private final String kid;
+        private final String jwkThumbprint;
+
+        private ParsedProof(SignedJWT signedJWT, String kid, String jwkThumbprint) {
+
+            this.signedJWT = signedJWT;
+            this.kid = kid;
+            this.jwkThumbprint = jwkThumbprint;
+        }
+
+        /**
+         * The {@code kid} from the embedded JWK in the proof header, or {@code null} if absent.
+         */
+        public String getKid() {
+
+            return kid;
+        }
+
+        /**
+         * SHA-256 JWK thumbprint computed from the proof header's {@code jwk} claim before full
+         * validation. Use this as the nonce cache key — it is derived from the actual public key
+         * material and is independent of the client-controlled {@code kid} value. Returns
+         * {@code null} if the {@code jwk} claim is absent (header validation will reject the proof
+         * when {@link DPoPProofValidator#validate} is called).
+         */
+        public String getJwkThumbprint() {
+
+            return jwkThumbprint;
+        }
+    }
+
+    /**
+     * The verified outputs of a successful DPoP proof validation.
+     */
+    public static final class ValidationResult {
+
+        private final String proofJkt;
+        private final String jti;
+
+        private ValidationResult(String proofJkt, String jti) {
+
+            this.proofJkt = proofJkt;
+            this.jti = jti;
+        }
+
+        /**
+         * Base64url SHA-256 JWK thumbprint of the proof's public key (from the validated header).
+         */
+        public String getProofJkt() {
+
+            return proofJkt;
+        }
+
+        /**
+         * The {@code jti} (JWT ID) from the proof claims — use for replay detection.
+         */
+        public String getJti() {
+
+            return jti;
+        }
+    }
+
+    /**
+     * Parses the raw DPoP proof string and extracts the fields needed before full validation:
+     * the JWK thumbprint (preferred nonce cache key, derived from key material) and {@code kid}.
+     * Pass the returned {@link ParsedProof} to {@link #validate} to complete
+     * the cryptographic checks.
+     *
+     * @param proofJwt raw value of the {@code DPoP} HTTP header
+     * @return parsed proof ready for full validation
+     * @throws DPoPProofException if the JWT is blank or not parseable
+     */
+    public ParsedProof parseDPoPProof(String proofJwt) throws DPoPProofException {
+
+        if (StringUtils.isBlank(proofJwt)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof header is missing");
+        }
+        SignedJWT signedJWT;
+        try {
+            signedJWT = SignedJWT.parse(proofJwt);
+        } catch (ParseException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof JWT is not parseable: " + e.getMessage(), e);
+        }
+        JWK jwk = signedJWT.getHeader().getJWK();
+        String kid = null;
+        String jwkThumbprint = null;
+        if (jwk != null) {
+            kid = jwk.getKeyID();
+            try {
+                jwkThumbprint = ThumbprintUtils.compute(SHA256_HASH_ALG, jwk).toString();
+            } catch (JOSEException e) {
+                log.debug(() -> "Failed to compute preliminary JWK thumbprint in parseDPoPProof; "
+                        + "header validation will reject this proof shortly", e);
+            }
+        }
+        return new ParsedProof(signedJWT, kid, jwkThumbprint);
+    }
+
+    /**
+     * Validates a pre-parsed DPoP proof JWT against RFC 9449 §4.3 rules.
+     * Accepts the result of {@link #parseDPoPProof} so the JWT string is parsed exactly once.
+     *
+     * @param parsedProof   result of {@link #parseDPoPProof}
+     * @param requestHtm    HTTP method of the request
+     * @param requestHtu    normalized HTTP URI of the request (no query/fragment)
+     * @param accessToken   raw access token (for {@code ath} verification), or {@code null}
+     * @param expectedNonce server nonce to match, or {@code null} if nonces are not required
+     * @return validation result containing the JWK thumbprint and {@code jti}
+     * @throws DPoPProofException if any validation step fails
+     */
+    public ValidationResult validate(ParsedProof parsedProof, String requestHtm, String requestHtu,
+                                     String accessToken, String expectedNonce) throws DPoPProofException {
+
+        JWSHeader header = parsedProof.signedJWT.getHeader();
+        JWK jwk = validateHeader(header);
+
+        verifySignature(parsedProof.signedJWT, jwk);
+
+        JWTClaimsSet claims = parseClaims(parsedProof.signedJWT);
+        validateClaims(claims, requestHtm, requestHtu, accessToken, expectedNonce);
+
+        return new ValidationResult(computeJwkThumbprint(jwk), claims.getJWTID());
+    }
+
+    private JWK validateHeader(JWSHeader header) throws DPoPProofException {
+        // RFC 9449 §4.3 rule 4: typ must be "dpop+jwt"
+        if (header.getType() == null || !equalsIgnoreCase(DPOP_JWT_TYPE, header.getType().getType())) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof typ must be \"dpop+jwt\", got: " + header.getType());
+        }
+
+        // RFC 9449 §4.3 rule 5: alg must be asymmetric and in the allow-list
+        JWSAlgorithm alg = header.getAlgorithm();
+        if (alg == null || JWSAlgorithm.Family.HMAC_SHA.contains(alg) || JWSAlgorithm.NONE.equals(alg)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof alg must be an asymmetric algorithm, got: " + alg);
+        }
+        if (!acceptedAlgorithms.contains(alg.getName())) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof alg \"" + alg.getName() + "\" is not in the accepted algorithm list");
+        }
+
+        // RFC 9449 §4.3 rule 6: jwk must be present
+        JWK jwk = header.getJWK();
+        if (jwk == null) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof header must contain a jwk claim");
+        }
+        // RFC 9449 §4.3 rule 7: jwk must not contain private key material
+        if (jwk.isPrivate()) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof jwk must not contain private key material");
+        }
+        return jwk;
+    }
+
+    private void verifySignature(SignedJWT signedJWT, JWK jwk) throws DPoPProofException {
+        try {
+            JWSVerifier verifier = buildVerifier(jwk);
+            if (!signedJWT.verify(verifier)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "DPoP proof signature verification failed");
+            }
+        } catch (JOSEException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof signature verification error: " + e.getMessage(), e);
+        }
+    }
+
+    private JWSVerifier buildVerifier(JWK jwk) throws JOSEException, DPoPProofException {
+        KeyType keyType = jwk.getKeyType();
+        if (KeyType.RSA.equals(keyType)) {
+            return new RSASSAVerifier(((RSAKey) jwk).toRSAPublicKey());
+        } else if (KeyType.EC.equals(keyType)) {
+            return new ECDSAVerifier(((ECKey) jwk).toECPublicKey());
+        } else if (KeyType.OKP.equals(keyType)) {
+            OctetKeyPair okp = (OctetKeyPair) jwk;
+            if (!Curve.Ed25519.equals(okp.getCurve())) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "Unsupported OKP curve: " + okp.getCurve());
+            }
+            return new Ed25519Verifier(okp.toPublicJWK());
+        }
+        throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                "Unsupported JWK key type: " + keyType);
+    }
+
+    private JWTClaimsSet parseClaims(SignedJWT signedJWT) throws DPoPProofException {
+
+        try {
+            return signedJWT.getJWTClaimsSet();
+        } catch (ParseException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "Failed to parse DPoP proof claims: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateClaims(JWTClaimsSet claims, String requestHtm, String requestHtu,
+                                String accessToken, String expectedNonce) throws DPoPProofException {
+
+        if (StringUtils.isBlank(claims.getJWTID())) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof must contain a jti claim");
+        }
+
+        // RFC 9449 §4.3 rule 8: htm must match request method
+        String htm = (String) claims.getClaim(DPoPConstants.Claims.HTM_CLAIM);
+        if (!equalsIgnoreCase(requestHtm, htm)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof htm \"" + htm + "\" does not match request method \"" + requestHtm + "\"");
+        }
+
+        // RFC 9449 §4.3 rule 9: htu must match normalized request URI
+        String htu = removeQueryAndFragment((String) claims.getClaim(DPoPConstants.Claims.HTU_CLAIM));
+        if (!normalizedUriEquals(requestHtu, htu)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof htu \"" + htu + "\" does not match request URI \"" + requestHtu + "\"");
+        }
+
+        // RFC 9449 §4.3 rule 11: iat must be within the acceptance window
+        Date iat = claims.getIssueTime();
+        if (iat == null) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof must contain an iat claim");
+        }
+        long now = System.currentTimeMillis();
+        if (Math.abs(now - iat.getTime()) > iatSkewMillis) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof iat is outside the acceptance window");
+        }
+
+        if (accessToken != null) {
+            // RFC 9449 §4.3 rule 12: ath must equal base64url(SHA-256(ASCII(accessToken)))
+            String ath = (String) claims.getClaim(DPoPConstants.Claims.ATH_CLAIM);
+            if (StringUtils.isBlank(ath)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "DPoP proof must contain an ath claim when an access token is presented");
+            }
+            String expectedAth = computeAth(accessToken);
+            if (!expectedAth.equals(ath)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "DPoP proof ath does not match the access token hash");
+            }
+        }
+
+        // RFC 9449 §4.3 rule 10: nonce claim must match the server-issued nonce when required
+        if (expectedNonce != null) {
+            String nonce = (String) claims.getClaim(DPoPConstants.Claims.NONCE_CLAIM);
+            if (!expectedNonce.equals(nonce)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                        "DPoP proof nonce is missing or does not match the server-issued nonce");
+            }
+        }
+    }
+
+    /**
+     * Computes the base64url-encoded SHA-256 JWK thumbprint per RFC 7638.
+     */
+    private String computeJwkThumbprint(JWK jwk) throws DPoPProofException {
+
+        try {
+            Base64URL thumbprint = ThumbprintUtils.compute(SHA256_HASH_ALG, jwk);
+            return thumbprint.toString();
+        } catch (JOSEException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "Failed to compute JWK thumbprint: " + e.getMessage(), e);
+        }
+    }
+
+    private String computeAth(String accessToken) throws DPoPProofException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(SHA256_HASH_ALG);
+            byte[] hash = digest.digest(accessToken.getBytes(StandardCharsets.US_ASCII));
+            return Base64URL.encode(hash).toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "SHA-256 not available", e);
+        }
+    }
+
+    private boolean normalizedUriEquals(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        return equalsIgnoreCase(stripTrailingSlash(a), stripTrailingSlash(b));
+    }
+
+    private String stripTrailingSlash(String uri) {
+        return uri.endsWith("/") ? uri.substring(0, uri.length() - 1) : uri;
+    }
+
+    private String removeQueryAndFragment(String url) throws DPoPProofException {
+        try {
+            if (StringUtils.isBlank(url)) {
+                return null;
+            }
+            final URI uri = new URI(url);
+            return new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), null, null).toString();
+        } catch (URISyntaxException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "Invalid URI syntax in the htu claim", e);
+        }
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/util/Challenge.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/util/Challenge.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.util;
+
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.context.MessageContext;
+import org.apache.http.HttpHeaders;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
+import org.wso2.financial.services.accelerator.common.logging.Log;
+import org.wso2.financial.services.accelerator.common.logging.LogFactory;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
+
+import java.util.Map;
+
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_NONCE_HEADER;
+
+/**
+ * Builds the RFC 9449 §7.1 {@code WWW-Authenticate: DPoP} challenge and dispatches a 401 Unauthorized response.
+ */
+public class Challenge {
+
+    private static final Log log = LogFactory.getLog(Challenge.class);
+
+    private final String acceptedAlgorithms;
+
+    public Challenge(String acceptedAlgorithms) {
+        this.acceptedAlgorithms = acceptedAlgorithms;
+    }
+
+    /**
+     * Sends a 401 response with a {@code WWW-Authenticate: DPoP} challenge per RFC 9449 §7.1.
+     *
+     * @param synCtx  current message context
+     * @param error   the RFC 9449 error code
+     * @param message human-readable description
+     * @param nonce   server-issued nonce to include, or {@code null}
+     */
+    public void send401(org.apache.synapse.MessageContext synCtx,
+                        DPoPProofException.ErrorCode error, String message, String nonce) {
+
+        MessageContext axis2MC = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        axis2MC.setProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED, Boolean.TRUE);
+        try {
+            RelayUtils.consumeAndDiscardMessage(axis2MC);
+        } catch (AxisFault axisFault) {
+            log.error("Error consuming request message during DPoP 401 response", axisFault);
+        }
+
+        StringBuilder challenge = new StringBuilder("DPoP");
+        challenge.append(" error=\"").append(error.getValue()).append("\"");
+        if (message != null) {
+            challenge.append(", error_description=\"")
+                    .append(message.replace("\"", "'")).append("\"");
+        }
+        if (acceptedAlgorithms != null) {
+            challenge.append(", algs=\"").append(acceptedAlgorithms).append("\"");
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> headers = (Map<String, String>)
+                axis2MC.getProperty(MessageContext.TRANSPORT_HEADERS);
+        if (headers != null) {
+            headers.put(HttpHeaders.WWW_AUTHENTICATE, challenge.toString());
+            if (nonce != null) {
+                headers.put(DPOP_NONCE_HEADER, nonce);
+            }
+            axis2MC.setProperty(MessageContext.TRANSPORT_HEADERS, headers);
+        }
+
+        synCtx.setProperty(APIMgtGatewayConstants.HTTP_RESPONSE_STATUS_CODE, 401);
+        Utils.send(synCtx, 401);
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/util/Challenge.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/util/Challenge.java
@@ -28,9 +28,11 @@ import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
 import org.wso2.carbon.apimgt.gateway.handlers.Utils;
 import org.wso2.financial.services.accelerator.common.logging.Log;
 import org.wso2.financial.services.accelerator.common.logging.LogFactory;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
 import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
 
 import java.util.Map;
+import java.util.TreeMap;
 
 import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_NONCE_HEADER;
 
@@ -76,16 +78,14 @@ public class Challenge {
             challenge.append(", algs=\"").append(acceptedAlgorithms).append("\"");
         }
 
-        @SuppressWarnings("unchecked")
-        Map<String, String> headers = (Map<String, String>)
-                axis2MC.getProperty(MessageContext.TRANSPORT_HEADERS);
-        if (headers != null) {
-            headers.put(HttpHeaders.WWW_AUTHENTICATE, challenge.toString());
-            if (nonce != null) {
-                headers.put(DPOP_NONCE_HEADER, nonce);
-            }
-            axis2MC.setProperty(MessageContext.TRANSPORT_HEADERS, headers);
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.put(HttpHeaders.WWW_AUTHENTICATE, challenge.toString());
+        if (nonce != null) {
+            headers.put(DPOP_NONCE_HEADER, nonce);
+            // RFC 9449 §8.2: responses carrying a nonce must not be cached.
+            headers.put(HttpHeaders.CACHE_CONTROL, DPoPConstants.CACHE_CONTROL_NO_STORE);
         }
+        axis2MC.setProperty(MessageContext.TRANSPORT_HEADERS, headers);
 
         synCtx.setProperty(APIMgtGatewayConstants.HTTP_RESPONSE_STATUS_CODE, 401);
         Utils.send(synCtx, 401);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/util/DPoPUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/util/DPoPUtils.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.util;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import org.apache.axis2.context.MessageContext;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.nhttp.NhttpConstants;
+import org.wso2.financial.services.accelerator.common.logging.Log;
+import org.wso2.financial.services.accelerator.common.logging.LogFactory;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.wso2.financial.services.accelerator.common.util.FinancialServicesUtils.equalsIgnoreCase;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_HEADER;
+
+/**
+ * Pure helpers used across the DPoP handler — JWT inspection, transport-header
+ * access, and request-URI normalization for {@code htu} comparison.
+ */
+public final class DPoPUtils {
+
+    private static final Log log = LogFactory.getLog(DPoPUtils.class);
+
+    private static final String PROPERTY_REQUEST_PATH = "REST_FULL_REQUEST_PATH";
+    private static final String PROPERTY_TRANSPORT = "TRANSPORT_IN_NAME";
+    private static final String HEADER_HOST = "Host";
+
+    private DPoPUtils() {
+    }
+
+    /**
+     * Extracts {@code cnf.jkt} from a JWT access token without verifying the
+     * signature — signature verification is the downstream authenticator's job.
+     */
+    public static String extractJktFromJwt(String accessToken) throws DPoPProofException {
+        try {
+            JWT jwt = JWTParser.parse(accessToken);
+            JWTClaimsSet claims = jwt.getJWTClaimsSet();
+            if (claims == null) {
+                return null;
+            }
+            Object cnf = claims.getClaim(DPoPConstants.Claims.CNF_CLAIM);
+            if (cnf instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Object jkt = ((Map<String, Object>) cnf).get(DPoPConstants.Claims.JKT_CLAIM);
+                return jkt != null ? jkt.toString() : null;
+            }
+            return null;
+        } catch (ParseException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                    "Failed to parse JWT access token for cnf.jkt extraction: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns true if {@code token} has the three-part JWS compact structure.
+     */
+    public static boolean isJwtToken(String token) {
+
+        if (StringUtils.isBlank(token)) {
+            return false;
+        }
+        return token.split("\\.").length == 3;
+    }
+
+    /**
+     * Reconstructs and normalizes the {@code htu} (HTTP target URI) for DPoP proof
+     * verification per RFC 9449 §4.3: query string and fragment are stripped.
+     *
+     * @return {@code scheme://host/path} or {@code null} if the URI cannot be built
+     */
+    public static String normalizeHtu(org.apache.synapse.MessageContext synCtx, Map<String, String> headers) {
+        try {
+            final String authority = headers.get(HEADER_HOST);
+            final String scheme = (String) synCtx.getProperty(PROPERTY_TRANSPORT);
+            final String path = (String) synCtx.getProperty(PROPERTY_REQUEST_PATH);
+            return new URI(scheme, authority, path, null, null).toString();
+        } catch (URISyntaxException e) {
+            log.error("Unable to construct URI from message context properties. Caused by, ", e);
+            return null;
+        }
+    }
+
+    private static Map<String, String> getHeaderMapByKey(org.apache.synapse.MessageContext synCtx, String propertyKey) {
+
+        @SuppressWarnings("unchecked")
+        final Map<String, String> headersMap =
+                (Map<String, String>) ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(propertyKey);
+        // Use a case-insensitive TreeMap because HTTP header names are case-insensitive
+        final Map<String, String> headersTreeMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (headersMap != null) {
+            headersTreeMap.putAll(headersMap);
+        }
+        return headersTreeMap;
+    }
+
+    /**
+     * Returns the request transport headers as a case-insensitive map.
+     */
+    public static Map<String, String> getTransportHeaders(org.apache.synapse.MessageContext synCtx) {
+
+        return getHeaderMapByKey(synCtx, MessageContext.TRANSPORT_HEADERS);
+    }
+
+    /**
+     * Returns any excess (duplicate) transport headers as a case-insensitive map.
+     * Used to detect multiple {@code DPoP} header fields per RFC 9449 §4.3.
+     */
+    public static Map<String, String> getExcessTransportHeaders(org.apache.synapse.MessageContext synCtx) {
+
+        return getHeaderMapByKey(synCtx, NhttpConstants.EXCESS_TRANSPORT_HEADERS);
+    }
+
+    /**
+     * Throws {@link DPoPProofException} if {@code htu} uses plain HTTP.
+     */
+    public static void checkHttps(final String htu) throws DPoPProofException {
+
+        if (htu != null && htu.startsWith("http://")) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP is not permitted over plain HTTP");
+        }
+    }
+
+    /**
+     * Returns {@code true} if the message context contains more than one {@code DPoP} header field.
+     */
+    public static boolean hasMultipleDPopHeaders(org.apache.synapse.MessageContext synCtx) {
+
+        final Map<String, String> excessTransportHeaders = DPoPUtils.getExcessTransportHeaders(synCtx);
+        return !excessTransportHeaders.isEmpty() && excessTransportHeaders.containsKey(DPOP_HEADER);
+    }
+
+    /**
+     * Strips the {@code "<scheme> "} prefix from {@code authHeader} and returns the token value,
+     * or {@code null} if the header is absent or does not start with the given scheme.
+     */
+    public static String extractToken(String authHeader, String scheme) {
+        if (authHeader == null) {
+            return null;
+        }
+        String prefix = scheme + " ";
+        if (authHeader.regionMatches(true, 0, prefix, 0, prefix.length())) {
+            return authHeader.substring(prefix.length()).trim();
+        }
+        return null;
+    }
+
+    /**
+     * Removes all entries for {@code name} from {@code headers}, case-insensitively.
+     */
+    public static void removeHeader(Map<String, String> headers, String name) {
+        headers.remove(name);
+        headers.entrySet().removeIf(e -> equalsIgnoreCase(name, e.getKey()));
+    }
+
+    /**
+     * Parses a comma-separated algorithm list. Returns the default set if the input is blank.
+     */
+    public static Set<String> parseAlgorithms(String csv) {
+        String value = StringUtils.isBlank(csv) ? DPoPConstants.Defaults.ACCEPTED_ALGORITHMS : csv;
+        Set<String> result = new HashSet<>();
+        for (String alg : value.split(",")) {
+            String trimmed = alg.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Parses {@code value} as a boolean. Returns {@code defaultValue} if {@code value} is {@code null}.
+     */
+    public static boolean parseBool(Object value, boolean defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(String.valueOf(value).trim());
+    }
+
+    /**
+     * Parses {@code value} as a long. Returns {@code defaultValue} if {@code value} is {@code null}
+     * or not a valid number.
+     */
+    public static long parseLong(Object value, long defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(String.valueOf(value).trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Parses {@code value} as a trimmed string. Returns {@code defaultValue} if {@code value} is
+     * {@code null} or blank.
+     */
+    public static String parseString(Object value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        String s = String.valueOf(value).trim();
+        return s.isEmpty() ? defaultValue : s;
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/util/DPoPUtils.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/dpop/util/DPoPUtils.java
@@ -111,8 +111,7 @@ public final class DPoPUtils {
 
     private static Map<String, String> getHeaderMapByKey(org.apache.synapse.MessageContext synCtx, String propertyKey) {
 
-        @SuppressWarnings("unchecked")
-        final Map<String, String> headersMap =
+        @SuppressWarnings("unchecked") final Map<String, String> headersMap =
                 (Map<String, String>) ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(propertyKey);
         // Use a case-insensitive TreeMap because HTTP header names are case-insensitive
         final Map<String, String> headersTreeMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -193,6 +192,9 @@ public final class DPoPUtils {
             if (!trimmed.isEmpty()) {
                 result.add(trimmed);
             }
+        }
+        if (result.isEmpty()) {
+            return parseAlgorithms(DPoPConstants.Defaults.ACCEPTED_ALGORITHMS);
         }
         return result;
     }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/executor/core/FSExtensionListenerImpl.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/main/java/org/wso2/financial/services/accelerator/gateway/executor/core/FSExtensionListenerImpl.java
@@ -18,14 +18,14 @@
 
 package org.wso2.financial.services.accelerator.gateway.executor.core;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpStatus;
 import org.wso2.carbon.apimgt.common.gateway.dto.ExtensionResponseDTO;
 import org.wso2.carbon.apimgt.common.gateway.dto.ExtensionResponseStatus;
 import org.wso2.carbon.apimgt.common.gateway.dto.RequestContextDTO;
 import org.wso2.carbon.apimgt.common.gateway.dto.ResponseContextDTO;
 import org.wso2.carbon.apimgt.common.gateway.extensionlistener.ExtensionListener;
+import org.wso2.financial.services.accelerator.common.logging.Log;
+import org.wso2.financial.services.accelerator.common.logging.LogFactory;
 import org.wso2.financial.services.accelerator.common.util.Generated;
 import org.wso2.financial.services.accelerator.gateway.cache.GatewayCacheKey;
 import org.wso2.financial.services.accelerator.gateway.executor.model.FSAPIRequestContext;
@@ -52,9 +52,7 @@ public class FSExtensionListenerImpl implements ExtensionListener {
         FSAPIRequestContext fsApiRequestContext = new FSAPIRequestContext(requestContextDTO, new HashMap<>());
         for (FinancialServicesGatewayExecutor gatewayExecutor :
                 GatewayDataHolder.getInstance().getRequestRouter().getExecutorsForRequest(fsApiRequestContext)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Executing preProcessRequest for executor: " + gatewayExecutor.getClass().getName());
-            }
+            log.debug(() -> "Executing preProcessRequest for executor: " + gatewayExecutor.getClass().getName());
             gatewayExecutor.preProcessRequest(fsApiRequestContext);
         }
 
@@ -75,9 +73,7 @@ public class FSExtensionListenerImpl implements ExtensionListener {
         FSAPIRequestContext fsApiRequestContext = new FSAPIRequestContext(requestContextDTO, contextProps);
         for (FinancialServicesGatewayExecutor gatewayExecutor :
                 GatewayDataHolder.getInstance().getRequestRouter().getExecutorsForRequest(fsApiRequestContext)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Executing postProcessRequest for executor: " + gatewayExecutor.getClass().getName());
-            }
+            log.debug(() -> "Executing postProcessRequest for executor: " + gatewayExecutor.getClass().getName());
             gatewayExecutor.postProcessRequest(fsApiRequestContext);
         }
 
@@ -97,9 +93,7 @@ public class FSExtensionListenerImpl implements ExtensionListener {
         FSAPIResponseContext fsApiResponseContext = new FSAPIResponseContext(responseContextDTO, contextProps);
         for (FinancialServicesGatewayExecutor gatewayExecutor :
                 GatewayDataHolder.getInstance().getRequestRouter().getExecutorsForResponse(fsApiResponseContext)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Executing preProcessResponse for executor: " + gatewayExecutor.getClass().getName());
-            }
+            log.debug(() -> "Executing preProcessResponse for executor: " + gatewayExecutor.getClass().getName());
             gatewayExecutor.preProcessResponse(fsApiResponseContext);
         }
 
@@ -119,9 +113,7 @@ public class FSExtensionListenerImpl implements ExtensionListener {
         FSAPIResponseContext fsApiResponseContext = new FSAPIResponseContext(responseContextDTO, contextProps);
         for (FinancialServicesGatewayExecutor gatewayExecutor :
                 GatewayDataHolder.getInstance().getRequestRouter().getExecutorsForResponse(fsApiResponseContext)) {
-            if (log.isDebugEnabled()) {
-                log.debug("Executing postProcessResponse for executor: " + gatewayExecutor.getClass().getName());
-            }
+            log.debug(() -> "Executing postProcessResponse for executor: " + gatewayExecutor.getClass().getName());
             gatewayExecutor.postProcessResponse(fsApiResponseContext);
         }
         ExtensionResponseDTO responseDTOForResponse = getResponseDTOForResponse(fsApiResponseContext);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPHandlerTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPHandlerTest.java
@@ -90,7 +90,6 @@ public class DPoPHandlerTest {
         mockNonceStrategy = Mockito.mock(NonceStrategy.class);
 
         // Inject all fields without calling init()
-        setField("globalDPoPEnabled", true);
         setField("apiDPoPEnabled", true);
         setField("iatSkewSeconds", 60L);
         setField("jtiCacheTtlSeconds", JTI_TTL);
@@ -102,8 +101,9 @@ public class DPoPHandlerTest {
         setField("challenge", mockChallenge);
         setField("nonceStrategy", mockNonceStrategy);
 
-        // Default: nonce not required
+        // Default: nonce not required, no rotation
         Mockito.when(mockNonceStrategy.requiresNonce(Mockito.anyString())).thenReturn(false);
+        Mockito.when(mockNonceStrategy.shouldRotate(Mockito.anyString())).thenReturn(false);
 
         mockSynCtx = Mockito.mock(org.apache.synapse.core.axis2.Axis2MessageContext.class);
         mockAxis2MC = Mockito.mock(MessageContext.class);
@@ -113,16 +113,6 @@ public class DPoPHandlerTest {
     @Test
     public void apiDPoPDisabledShouldPassThrough() throws Exception {
         setField("apiDPoPEnabled", false);
-
-        boolean result = handler.handleRequest(mockSynCtx);
-
-        assertTrue(result);
-        Mockito.verifyNoInteractions(mockValidator, mockCache, mockBinder, mockChallenge);
-    }
-
-    @Test
-    public void globalDPoPDisabledShouldPassThrough() throws Exception {
-        setField("globalDPoPEnabled", false);
 
         boolean result = handler.handleRequest(mockSynCtx);
 
@@ -449,48 +439,6 @@ public class DPoPHandlerTest {
     }
 
     @Test
-    public void validDPoPRequestWithNonceShouldConsumeNonce() throws Exception {
-        Map<String, String> headers = makeHeaders(
-                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
-                HEADER_DPOP, DPOP_PROOF);
-        String activeNonce = "server-issued-nonce";
-
-        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
-        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
-        Mockito.when(mockParsed.getKid()).thenReturn(null);
-
-        DPoPProofValidator.ValidationResult mockResult = Mockito.mock(DPoPProofValidator.ValidationResult.class);
-        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
-        Mockito.when(mockResult.getJti()).thenReturn(JTI);
-
-        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
-            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
-            utilsStatic.when(() -> DPoPUtils.extractToken(
-                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
-            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
-            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
-            utilsStatic.when(() -> DPoPUtils.removeHeader(Mockito.any(), Mockito.any()))
-                    .thenAnswer(inv -> null);
-
-            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
-            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
-            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
-            Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(true);
-            Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(activeNonce);
-            Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, activeNonce))
-                    .thenReturn(mockResult);
-            Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
-            Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
-            Mockito.when(mockCache.isNonceValidAndConsumed(JWK_THUMBPRINT, activeNonce)).thenReturn(true);
-
-            boolean result = handler.handleRequest(mockSynCtx);
-
-            assertTrue(result);
-            Mockito.verify(mockCache).isNonceValidAndConsumed(JWK_THUMBPRINT, activeNonce);
-        }
-    }
-
-    @Test
     public void validDPoPRequestShouldStripDPoPHeaderWhenConfigured() throws Exception {
         setField("stripDpopHeader", true);
         Map<String, String> headers = makeHeaders(
@@ -526,6 +474,143 @@ public class DPoPHandlerTest {
 
             assertTrue(result);
             utilsStatic.verify(() -> DPoPUtils.removeHeader(headers, HEADER_DPOP));
+        }
+    }
+
+    @Test
+    public void validDPoPRequestWithNonceShouldReuseNonceWhenRotationNotNeeded() throws Exception {
+        // shouldRotate returns false (default from setUp) — issueNonce must never be called
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+        String activeNonce = "server-issued-nonce";
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult = Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+            utilsStatic.when(() -> DPoPUtils.removeHeader(Mockito.any(), Mockito.any()))
+                    .thenAnswer(inv -> null);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+            Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(true);
+            Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(activeNonce);
+            Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, activeNonce))
+                    .thenReturn(mockResult);
+            Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+            Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+            // shouldRotate already returns false (setUp default)
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertTrue(result);
+            Mockito.verify(mockCache, Mockito.never()).issueNonce(Mockito.any());
+            Mockito.verify(mockSynCtx, Mockito.never())
+                    .setProperty(Mockito.eq(DPoPConstants.DPOP_RESPONSE_NONCE_PROPERTY), Mockito.any());
+        }
+    }
+
+    @Test
+    public void validDPoPRequestShouldRotateNonceInResponseWhenStrategyDecides() throws Exception {
+        // shouldRotate returns true → issueNonce is called and property is set on synCtx
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+        String activeNonce = "server-issued-nonce";
+        String rotatedNonce = "rotated-nonce";
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult = Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+            utilsStatic.when(() -> DPoPUtils.removeHeader(Mockito.any(), Mockito.any()))
+                    .thenAnswer(inv -> null);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+            Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(true);
+            Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(activeNonce);
+            Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, activeNonce))
+                    .thenReturn(mockResult);
+            Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+            Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+            Mockito.when(mockNonceStrategy.shouldRotate(JWK_THUMBPRINT)).thenReturn(true);
+            Mockito.when(mockCache.issueNonce(JWK_THUMBPRINT)).thenReturn(rotatedNonce);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertTrue(result);
+            Mockito.verify(mockCache).issueNonce(JWK_THUMBPRINT);
+            Mockito.verify(mockSynCtx).setProperty(DPoPConstants.DPOP_RESPONSE_NONCE_PROPERTY, rotatedNonce);
+        }
+    }
+
+    @Test
+    public void section11_3ActiveNonceWithoutStrategyRequirementShouldEnforceNonce() throws Exception {
+        // RFC 9449 §11.3: once a nonce has been issued the server must require it even
+        // if requiresNonce() returns false (e.g. between rotation intervals in a rotating strategy).
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+        String activeNonce = "previously-issued-nonce";
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult = Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+            utilsStatic.when(() -> DPoPUtils.removeHeader(Mockito.any(), Mockito.any()))
+                    .thenAnswer(inv -> null);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+            // requiresNonce returns false (setUp default) but an active nonce exists
+            Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(false);
+            Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(activeNonce);
+            // validate must be called with the active nonce — §11.3 enforcement
+            Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, activeNonce))
+                    .thenReturn(mockResult);
+            Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+            Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertTrue(result);
+            // The critical assertion: validate was called with the active nonce, not null
+            Mockito.verify(mockValidator).validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, activeNonce);
         }
     }
 

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPHandlerTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/DPoPHandlerTest.java
@@ -1,0 +1,556 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop;
+
+import org.apache.axis2.Constants;
+import org.apache.axis2.context.MessageContext;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.financial.services.accelerator.gateway.dpop.binding.AccessTokenBinder;
+import org.wso2.financial.services.accelerator.gateway.dpop.cache.DPoPCacheProvider;
+import org.wso2.financial.services.accelerator.gateway.dpop.cache.DPoPJtiCache;
+import org.wso2.financial.services.accelerator.gateway.dpop.cache.DPoPNonceCache;
+import org.wso2.financial.services.accelerator.gateway.dpop.nonce.NonceStrategy;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofValidator;
+import org.wso2.financial.services.accelerator.gateway.dpop.util.Challenge;
+import org.wso2.financial.services.accelerator.gateway.dpop.util.DPoPUtils;
+import org.wso2.financial.services.accelerator.gateway.internal.GatewayDataHolder;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link DPoPHandler}. All private collaborator fields are injected
+ * via reflection so that {@code init()} — which requires Carbon/APIM runtime — is
+ * never called.
+ */
+public class DPoPHandlerTest {
+
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String HEADER_DPOP = "DPoP";
+    private static final String BEARER_TAG = "Bearer ";
+    private static final String DPOP_SCHEME = "DPoP";
+    private static final String ACCESS_TOKEN = "test-access-token";
+    private static final String DPOP_PROOF = "dpop.proof.jwt";
+    private static final String JWK_THUMBPRINT = "some-jwk-thumbprint";
+    private static final String JTI = "unique-jti";
+    private static final String HTU = "https://api.example.com/resource";
+    private static final String HTTP_METHOD = "GET";
+    private static final long NONCE_TTL = 300L;
+    private static final long JTI_TTL = 120L;
+
+    private DPoPHandler handler;
+    private DPoPProofValidator mockValidator;
+    private DPoPCacheProvider mockCache;
+    private AccessTokenBinder mockBinder;
+    private Challenge mockChallenge;
+    private NonceStrategy mockNonceStrategy;
+
+    private org.apache.synapse.core.axis2.Axis2MessageContext mockSynCtx;
+    private MessageContext mockAxis2MC;
+
+    @BeforeClass
+    public void beforeClass() {
+        System.setProperty("carbon.home", "/");
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        handler = new DPoPHandler();
+        mockValidator = Mockito.mock(DPoPProofValidator.class);
+        mockCache = Mockito.mock(DPoPCacheProvider.class);
+        mockBinder = Mockito.mock(AccessTokenBinder.class);
+        mockChallenge = Mockito.mock(Challenge.class);
+        mockNonceStrategy = Mockito.mock(NonceStrategy.class);
+
+        // Inject all fields without calling init()
+        setField("globalDPoPEnabled", true);
+        setField("apiDPoPEnabled", true);
+        setField("iatSkewSeconds", 60L);
+        setField("jtiCacheTtlSeconds", JTI_TTL);
+        setField("stripDpopHeader", false);
+        setField("httpsRequired", false);
+        setField("proofValidator", mockValidator);
+        setField("cacheProvider", mockCache);
+        setField("accessTokenBinder", mockBinder);
+        setField("challenge", mockChallenge);
+        setField("nonceStrategy", mockNonceStrategy);
+
+        // Default: nonce not required
+        Mockito.when(mockNonceStrategy.requiresNonce(Mockito.anyString())).thenReturn(false);
+
+        mockSynCtx = Mockito.mock(org.apache.synapse.core.axis2.Axis2MessageContext.class);
+        mockAxis2MC = Mockito.mock(MessageContext.class);
+        Mockito.when(mockSynCtx.getAxis2MessageContext()).thenReturn(mockAxis2MC);
+    }
+
+    @Test
+    public void apiDPoPDisabledShouldPassThrough() throws Exception {
+        setField("apiDPoPEnabled", false);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        Mockito.verifyNoInteractions(mockValidator, mockCache, mockBinder, mockChallenge);
+    }
+
+    @Test
+    public void globalDPoPDisabledShouldPassThrough() throws Exception {
+        setField("globalDPoPEnabled", false);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        Mockito.verifyNoInteractions(mockValidator, mockCache, mockBinder, mockChallenge);
+    }
+
+    @Test
+    public void noTransportHeadersShouldPassThrough() {
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx))
+                    .thenReturn(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertTrue(result);
+        }
+    }
+
+    @Test
+    public void bearerTokenWithNoDPoPHeaderAndNoJktShouldPassThrough() throws Exception {
+        Map<String, String> headers = makeHeaders(AUTH_HEADER, BEARER_TAG + ACCESS_TOKEN);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(BEARER_TAG + ACCESS_TOKEN, "Bearer"))
+                    .thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertTrue(result);
+            Mockito.verify(mockChallenge, Mockito.never())
+                    .send401(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        }
+    }
+
+    @Test
+    public void dpopBoundBearerTokenWithoutProofShouldReject() throws Exception {
+        // No DPoP header, but token has cnf.jkt
+        Map<String, String> headers = makeHeaders(AUTH_HEADER, BEARER_TAG + ACCESS_TOKEN);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(BEARER_TAG + ACCESS_TOKEN, "Bearer"))
+                    .thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertFalse(result);
+            Mockito.verify(mockChallenge).send401(
+                    Mockito.eq(mockSynCtx),
+                    Mockito.eq(DPoPProofException.ErrorCode.INVALID_TOKEN),
+                    Mockito.any(),
+                    Mockito.isNull());
+        }
+    }
+
+    @Test
+    public void validDPoPRequestShouldSucceedAndRewriteAuthHeader() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn("kid-1");
+
+        DPoPProofValidator.ValidationResult mockResult = Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+            utilsStatic.when(() -> DPoPUtils.removeHeader(Mockito.any(), Mockito.any()))
+                    .thenAnswer(inv -> null);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD))
+                    .thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+            Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, null))
+                    .thenReturn(mockResult);
+            Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+            Mockito.doNothing().when(mockBinder).verifyBinding(JWK_THUMBPRINT, JWK_THUMBPRINT);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertTrue(result);
+            Mockito.verify(mockChallenge, Mockito.never())
+                    .send401(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+        }
+    }
+
+    @Test
+    public void parseDPoPProofExceptionShouldSend401AndReturnFalse() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF))
+                    .thenThrow(new DPoPProofException(
+                            DPoPProofException.ErrorCode.INVALID_DPOP_PROOF, "Bad proof"));
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertFalse(result);
+            Mockito.verify(mockChallenge).send401(
+                    Mockito.eq(mockSynCtx),
+                    Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                    Mockito.any(),
+                    Mockito.isNull());
+        }
+    }
+
+    @Test
+    public void nonceRequiredButAbsentShouldIssueNonceAndSend401() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        String issuedNonce = "fresh-server-nonce";
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD))
+                    .thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+            // Nonce is required but no active nonce exists
+            Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(true);
+            Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(null);
+            Mockito.when(mockCache.issueNonce(JWK_THUMBPRINT)).thenReturn(issuedNonce);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertFalse(result);
+            Mockito.verify(mockCache).issueNonce(JWK_THUMBPRINT);
+            Mockito.verify(mockChallenge).send401(
+                    Mockito.eq(mockSynCtx),
+                    Mockito.eq(DPoPProofException.ErrorCode.USE_DPOP_NONCE),
+                    Mockito.any(),
+                    Mockito.eq(issuedNonce));
+        }
+    }
+
+    @Test
+    public void jtiReplayShouldRejectRequest() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult = Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD))
+                    .thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+            Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, null))
+                    .thenReturn(mockResult);
+            // Replay: isJtiFirstUse returns false
+            Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(false);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertFalse(result);
+            Mockito.verify(mockChallenge).send401(
+                    Mockito.eq(mockSynCtx),
+                    Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                    Mockito.any(),
+                    Mockito.isNull());
+        }
+    }
+
+    @Test
+    public void multipleDPoPHeadersShouldRejectRequest() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            // Multiple DPoP headers
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(true);
+
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertFalse(result);
+            Mockito.verify(mockChallenge).send401(
+                    Mockito.eq(mockSynCtx),
+                    Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                    Mockito.any(),
+                    Mockito.isNull());
+        }
+    }
+
+    @Test
+    public void handleResponseShouldAlwaysReturnTrue() {
+        assertTrue(handler.handleResponse(mockSynCtx));
+    }
+
+    @Test
+    public void initShouldBuildCollaboratorsUsingDefaultsWhenServiceUnavailable() {
+        try (MockedStatic<GatewayDataHolder> gdhStatic = Mockito.mockStatic(GatewayDataHolder.class);
+             MockedConstruction<DPoPJtiCache> ignored1 = Mockito.mockConstruction(DPoPJtiCache.class);
+             MockedConstruction<DPoPNonceCache> ignored2 = Mockito.mockConstruction(DPoPNonceCache.class)) {
+
+            GatewayDataHolder mockHolder = Mockito.mock(GatewayDataHolder.class);
+            Mockito.when(mockHolder.getFinancialServicesConfigurationService()).thenReturn(null);
+            gdhStatic.when(GatewayDataHolder::getInstance).thenReturn(mockHolder);
+
+            handler.init(Mockito.mock(SynapseEnvironment.class));
+        }
+    }
+
+    @Test
+    public void destroyShouldCompleteWithoutError() {
+        handler.destroy();
+    }
+
+    @Test
+    public void dpopSchemeWithoutProofHeaderShouldRejectWithInvalidProof() throws Exception {
+        Map<String, String> headers = makeHeaders(AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertFalse(result);
+            Mockito.verify(mockChallenge).send401(
+                    Mockito.eq(mockSynCtx),
+                    Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                    Mockito.any(), Mockito.isNull());
+        }
+    }
+
+    @Test
+    public void httpsRequiredShouldRejectPlainHttpRequest() throws Exception {
+        setField("httpsRequired", true);
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers))
+                    .thenReturn("http://api.example.com/resource");
+            utilsStatic.when(() -> DPoPUtils.checkHttps("http://api.example.com/resource"))
+                    .thenThrow(new DPoPProofException(
+                            DPoPProofException.ErrorCode.INVALID_DPOP_PROOF, "HTTPS required"));
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertFalse(result);
+            Mockito.verify(mockChallenge).send401(
+                    Mockito.eq(mockSynCtx),
+                    Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                    Mockito.any(), Mockito.isNull());
+        }
+    }
+
+    @Test
+    public void validDPoPRequestWithNonceShouldConsumeNonce() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+        String activeNonce = "server-issued-nonce";
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult = Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+            utilsStatic.when(() -> DPoPUtils.removeHeader(Mockito.any(), Mockito.any()))
+                    .thenAnswer(inv -> null);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+            Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(true);
+            Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(activeNonce);
+            Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, activeNonce))
+                    .thenReturn(mockResult);
+            Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+            Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+            Mockito.when(mockCache.isNonceValidAndConsumed(JWK_THUMBPRINT, activeNonce)).thenReturn(true);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertTrue(result);
+            Mockito.verify(mockCache).isNonceValidAndConsumed(JWK_THUMBPRINT, activeNonce);
+        }
+    }
+
+    @Test
+    public void validDPoPRequestShouldStripDPoPHeaderWhenConfigured() throws Exception {
+        setField("stripDpopHeader", true);
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult = Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        try (MockedStatic<DPoPUtils> utilsStatic = Mockito.mockStatic(DPoPUtils.class)) {
+            utilsStatic.when(() -> DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+            utilsStatic.when(() -> DPoPUtils.extractToken(
+                    DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+            utilsStatic.when(() -> DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+            utilsStatic.when(() -> DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+            utilsStatic.when(() -> DPoPUtils.removeHeader(Mockito.any(), Mockito.any()))
+                    .thenAnswer(inv -> null);
+
+            Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+            Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+            Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+            Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, null))
+                    .thenReturn(mockResult);
+            Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+            Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+
+            boolean result = handler.handleRequest(mockSynCtx);
+
+            assertTrue(result);
+            utilsStatic.verify(() -> DPoPUtils.removeHeader(headers, HEADER_DPOP));
+        }
+    }
+
+    private Map<String, String> makeHeaders(String... keyValues) {
+        Map<String, String> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (int i = 0; i < keyValues.length - 1; i += 2) {
+            map.put(keyValues[i], keyValues[i + 1]);
+        }
+        return map;
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field field = findField(handler.getClass(), name);
+        field.setAccessible(true);
+        field.set(handler, value);
+    }
+
+    private Field findField(Class<?> clazz, String name) throws NoSuchFieldException {
+        try {
+            return clazz.getDeclaredField(name);
+        } catch (NoSuchFieldException e) {
+            if (clazz.getSuperclass() != null) {
+                return findField(clazz.getSuperclass(), name);
+            }
+            throw e;
+        }
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/AccessTokenBinderTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/AccessTokenBinderTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.binding;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.ThumbprintUtils;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.SHA256_HASH_ALG;
+
+/**
+ * Unit tests for {@link AccessTokenBinder}. Covers JWT and opaque-token paths
+ * and the mismatch / missing-binding error cases.
+ */
+public class AccessTokenBinderTest {
+
+    private ECKey ecKey;
+    private String correctJkt;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        ecKey = new ECKeyGenerator(Curve.P_256).generate();
+        correctJkt = ThumbprintUtils.compute(SHA256_HASH_ALG, ecKey.toPublicJWK()).toString();
+    }
+
+    @Test
+    public void jwtWithMatchingJktShouldPass() throws Exception {
+        String jwtToken = buildJwtWithCnf(ecKey, correctJkt);
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(null));
+
+        String tokenJkt = binder.resolveJkt(jwtToken);
+        binder.verifyBinding(tokenJkt, correctJkt);
+    }
+
+    @Test
+    public void jwtWithMismatchedJktShouldFail() throws Exception {
+        ECKey otherKey = new ECKeyGenerator(Curve.P_256).generate();
+        String otherJkt = ThumbprintUtils.compute(SHA256_HASH_ALG, otherKey.toPublicJWK()).toString();
+        String jwtToken = buildJwtWithCnf(ecKey, otherJkt);
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(null));
+
+        String tokenJkt = binder.resolveJkt(jwtToken);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_TOKEN, () -> binder.verifyBinding(tokenJkt, correctJkt));
+    }
+
+    @Test
+    public void jwtWithoutCnfClaimShouldFail() throws Exception {
+        String jwtToken = buildJwtWithoutCnf();
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(null));
+
+        String tokenJkt = binder.resolveJkt(jwtToken);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                () -> binder.verifyBinding(tokenJkt, correctJkt));
+    }
+
+    @Test
+    public void opaqueTokenWithMatchingJktShouldPass() throws Exception {
+        String opaqueToken = "opaque_token_no_dots";
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(correctJkt));
+
+        String tokenJkt = binder.resolveJkt(opaqueToken);
+        binder.verifyBinding(tokenJkt, correctJkt);
+    }
+
+    @Test
+    public void opaqueTokenWithMismatchedJktShouldFail() throws Exception {
+        String opaqueToken = "opaque_token_no_dots";
+        ECKey otherKey = new ECKeyGenerator(Curve.P_256).generate();
+        String otherJkt = ThumbprintUtils.compute(SHA256_HASH_ALG, otherKey.toPublicJWK()).toString();
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(otherJkt));
+
+        String tokenJkt = binder.resolveJkt(opaqueToken);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                () -> binder.verifyBinding(tokenJkt, correctJkt));
+    }
+
+    @Test
+    public void opaqueTokenWithNoJktShouldFail() throws Exception {
+        String opaqueToken = "opaque_token_no_dots";
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(null));
+
+        String tokenJkt = binder.resolveJkt(opaqueToken);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                () -> binder.verifyBinding(tokenJkt, correctJkt));
+    }
+
+    private String buildJwtWithCnf(ECKey key, String jkt) throws Exception {
+        Map<String, Object> cnf = new HashMap<>();
+        cnf.put(DPoPConstants.Claims.JKT_CLAIM, jkt);
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .claim(DPoPConstants.Claims.CNF_CLAIM, cnf)
+                .subject("test-client")
+                .build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(key));
+        return jwt.serialize();
+    }
+
+    private String buildJwtWithoutCnf() throws Exception {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder().subject("test-client").build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(ecKey));
+        return jwt.serialize();
+    }
+
+    private IntrospectionClient mockIntrospection(String jkt) throws Exception {
+        IntrospectionClient mock = Mockito.mock(IntrospectionClient.class);
+        Mockito.when(mock.getJwkThumbprint(Mockito.anyString())).thenReturn(jkt);
+        return mock;
+    }
+
+    private void assertErrorCode(DPoPProofException.ErrorCode expected, ThrowingRunnable call) {
+        try {
+            call.run();
+            fail("Expected DPoPProofException with error code " + expected);
+        } catch (DPoPProofException e) {
+            assertEquals(e.getErrorCode(), expected);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e);
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/IntrospectionClientTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/binding/IntrospectionClientTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.binding;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
+import org.wso2.carbon.apimgt.api.model.KeyManager;
+import org.wso2.carbon.apimgt.impl.dto.KeyManagerDto;
+import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
+
+/**
+ * Unit tests for {@link IntrospectionClient}. Uses {@code mockStatic} for
+ * {@link PrivilegedCarbonContext} and {@link KeyManagerHolder} to avoid a Carbon runtime.
+ */
+public class IntrospectionClientTest {
+
+    private static final String TENANT = "carbon.super";
+    private static final String TOKEN = "opaque-access-token";
+    private static final String JKT = "some-jwk-thumbprint-value";
+    private static final long CACHE_TTL = 60L;
+
+    @BeforeClass
+    public void beforeClass() {
+        // Required to allow Carbon context classes to initialize their static blocks
+        // before mockStatic intercepts them — same pattern used in other Carbon tests.
+        System.setProperty("carbon.home", "/");
+    }
+
+    @Test
+    public void secondCallShouldUseCacheAndNotIntrospect() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        try (MockedStatic<PrivilegedCarbonContext> pccStatic =
+                     Mockito.mockStatic(PrivilegedCarbonContext.class);
+             MockedStatic<KeyManagerHolder> kmhStatic =
+                     Mockito.mockStatic(KeyManagerHolder.class)) {
+
+            PrivilegedCarbonContext mockPcc = Mockito.mock(PrivilegedCarbonContext.class);
+            pccStatic.when(PrivilegedCarbonContext::getThreadLocalCarbonContext).thenReturn(mockPcc);
+            Mockito.when(mockPcc.getTenantDomain(true)).thenReturn(TENANT);
+
+            KeyManager mockKm = buildKeyManager(TOKEN, JKT);
+            kmhStatic.when(() -> KeyManagerHolder.getTenantKeyManagers(TENANT))
+                    .thenReturn(buildKmDtoMap(mockKm));
+
+            // First call triggers introspection
+            String first = client.getJwkThumbprint(TOKEN);
+            assertEquals(first, JKT);
+
+            // Second call must hit the cache — KeyManagerHolder must NOT be called again
+            String second = client.getJwkThumbprint(TOKEN);
+            assertEquals(second, JKT);
+
+            kmhStatic.verify(() -> KeyManagerHolder.getTenantKeyManagers(TENANT),
+                    Mockito.times(1));
+        }
+    }
+
+    @Test
+    public void cacheMissWithJktShouldReturnThumbprint() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        try (MockedStatic<PrivilegedCarbonContext> pccStatic =
+                     Mockito.mockStatic(PrivilegedCarbonContext.class);
+             MockedStatic<KeyManagerHolder> kmhStatic =
+                     Mockito.mockStatic(KeyManagerHolder.class)) {
+
+            PrivilegedCarbonContext mockPcc = Mockito.mock(PrivilegedCarbonContext.class);
+            pccStatic.when(PrivilegedCarbonContext::getThreadLocalCarbonContext).thenReturn(mockPcc);
+            Mockito.when(mockPcc.getTenantDomain(true)).thenReturn(TENANT);
+
+            KeyManager mockKm = buildKeyManager(TOKEN, JKT);
+            kmhStatic.when(() -> KeyManagerHolder.getTenantKeyManagers(TENANT))
+                    .thenReturn(buildKmDtoMap(mockKm));
+
+            String result = client.getJwkThumbprint(TOKEN);
+
+            assertEquals(result, JKT);
+        }
+    }
+
+    // ─── Cache miss, token valid but no cnf claim → null not cached ───────────
+
+    @Test
+    public void cacheMissWithNoCnfShouldReturnNullAndNotCache() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        try (MockedStatic<PrivilegedCarbonContext> pccStatic =
+                     Mockito.mockStatic(PrivilegedCarbonContext.class);
+             MockedStatic<KeyManagerHolder> kmhStatic =
+                     Mockito.mockStatic(KeyManagerHolder.class)) {
+
+            PrivilegedCarbonContext mockPcc = Mockito.mock(PrivilegedCarbonContext.class);
+            pccStatic.when(PrivilegedCarbonContext::getThreadLocalCarbonContext).thenReturn(mockPcc);
+            Mockito.when(mockPcc.getTenantDomain(true)).thenReturn(TENANT);
+
+            // Token valid but has no cnf claim
+            KeyManager mockKm = buildKeyManagerNoCnf(TOKEN);
+            kmhStatic.when(() -> KeyManagerHolder.getTenantKeyManagers(TENANT))
+                    .thenReturn(buildKmDtoMap(mockKm));
+
+            String first = client.getJwkThumbprint(TOKEN);
+            assertNull(first);
+
+            // Second call should also call introspection (null was not cached)
+            String second = client.getJwkThumbprint(TOKEN);
+            assertNull(second);
+
+            kmhStatic.verify(() -> KeyManagerHolder.getTenantKeyManagers(TENANT),
+                    Mockito.times(2));
+        }
+    }
+
+    // ─── APIManagementException from one KM → tries next; all fail → throws ──
+
+    @Test
+    public void allKeyManagersThrowingShouldThrowIntrospectionException() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        try (MockedStatic<PrivilegedCarbonContext> pccStatic =
+                     Mockito.mockStatic(PrivilegedCarbonContext.class);
+             MockedStatic<KeyManagerHolder> kmhStatic =
+                     Mockito.mockStatic(KeyManagerHolder.class)) {
+
+            PrivilegedCarbonContext mockPcc = Mockito.mock(PrivilegedCarbonContext.class);
+            pccStatic.when(PrivilegedCarbonContext::getThreadLocalCarbonContext).thenReturn(mockPcc);
+            Mockito.when(mockPcc.getTenantDomain(true)).thenReturn(TENANT);
+
+            KeyManager throwingKm = Mockito.mock(KeyManager.class);
+            Mockito.when(throwingKm.getTokenMetaData(TOKEN))
+                    .thenThrow(new APIManagementException("service unavailable"));
+            kmhStatic.when(() -> KeyManagerHolder.getTenantKeyManagers(TENANT))
+                    .thenReturn(buildKmDtoMap(throwingKm));
+
+            try {
+                client.getJwkThumbprint(TOKEN);
+                fail("Expected IntrospectionException");
+            } catch (IntrospectionClient.IntrospectionException e) {
+                // expected — all key managers exhausted
+            }
+        }
+    }
+
+    @Test
+    public void noKeyManagersConfiguredShouldThrowIntrospectionException() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        try (MockedStatic<PrivilegedCarbonContext> pccStatic =
+                     Mockito.mockStatic(PrivilegedCarbonContext.class);
+             MockedStatic<KeyManagerHolder> kmhStatic =
+                     Mockito.mockStatic(KeyManagerHolder.class)) {
+
+            PrivilegedCarbonContext mockPcc = Mockito.mock(PrivilegedCarbonContext.class);
+            pccStatic.when(PrivilegedCarbonContext::getThreadLocalCarbonContext).thenReturn(mockPcc);
+            Mockito.when(mockPcc.getTenantDomain(true)).thenReturn(TENANT);
+
+            kmhStatic.when(() -> KeyManagerHolder.getTenantKeyManagers(TENANT))
+                    .thenReturn(Collections.emptyMap());
+
+            try {
+                client.getJwkThumbprint(TOKEN);
+                fail("Expected IntrospectionException");
+            } catch (IntrospectionClient.IntrospectionException e) {
+                // expected
+            }
+        }
+    }
+
+    @Test
+    public void nullAccessTokenInfoShouldContinueToNextKeyManager() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        try (MockedStatic<PrivilegedCarbonContext> pccStatic =
+                     Mockito.mockStatic(PrivilegedCarbonContext.class);
+             MockedStatic<KeyManagerHolder> kmhStatic =
+                     Mockito.mockStatic(KeyManagerHolder.class)) {
+
+            PrivilegedCarbonContext mockPcc = Mockito.mock(PrivilegedCarbonContext.class);
+            pccStatic.when(PrivilegedCarbonContext::getThreadLocalCarbonContext).thenReturn(mockPcc);
+            Mockito.when(mockPcc.getTenantDomain(true)).thenReturn(TENANT);
+
+            // First KM returns null; second returns a valid result with jkt
+            KeyManager nullKm = Mockito.mock(KeyManager.class);
+            Mockito.when(nullKm.getTokenMetaData(TOKEN)).thenReturn(null);
+
+            KeyManager validKm = buildKeyManager(TOKEN, JKT);
+
+            Map<String, KeyManagerDto> dtoMap = new HashMap<>();
+            dtoMap.put("nullKm", buildDto(nullKm));
+            dtoMap.put("validKm", buildDto(validKm));
+
+            kmhStatic.when(() -> KeyManagerHolder.getTenantKeyManagers(TENANT))
+                    .thenReturn(dtoMap);
+
+            String result = client.getJwkThumbprint(TOKEN);
+            assertEquals(result, JKT);
+        }
+    }
+
+    private KeyManager buildKeyManager(String token, String jkt) throws APIManagementException {
+        Map<String, Object> cnf = new HashMap<>();
+        cnf.put(DPoPConstants.Claims.JKT_CLAIM, jkt);
+
+        AccessTokenInfo tokenInfo = Mockito.mock(AccessTokenInfo.class);
+        Mockito.when(tokenInfo.isTokenValid()).thenReturn(true);
+        Mockito.when(tokenInfo.getParameter(DPoPConstants.Claims.CNF_CLAIM)).thenReturn(cnf);
+
+        KeyManager km = Mockito.mock(KeyManager.class);
+        Mockito.when(km.getTokenMetaData(token)).thenReturn(tokenInfo);
+        return km;
+    }
+
+    private KeyManager buildKeyManagerNoCnf(String token) throws APIManagementException {
+        AccessTokenInfo tokenInfo = Mockito.mock(AccessTokenInfo.class);
+        Mockito.when(tokenInfo.isTokenValid()).thenReturn(true);
+        Mockito.when(tokenInfo.getParameter(DPoPConstants.Claims.CNF_CLAIM)).thenReturn(null);
+
+        KeyManager km = Mockito.mock(KeyManager.class);
+        Mockito.when(km.getTokenMetaData(token)).thenReturn(tokenInfo);
+        return km;
+    }
+
+    private Map<String, KeyManagerDto> buildKmDtoMap(KeyManager km) {
+        return Collections.singletonMap("defaultKm", buildDto(km));
+    }
+
+    private KeyManagerDto buildDto(KeyManager km) {
+        KeyManagerDto dto = new KeyManagerDto();
+        dto.setKeyManager(km);
+        return dto;
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/LocalDPoPCacheProviderTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/LocalDPoPCacheProviderTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.cache;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link LocalDPoPCacheProvider}.
+ * Uses reflection to inject mocked {@link DPoPJtiCache} and {@link DPoPNonceCache}
+ * so that {@code initialize()} — which requires the Carbon cache infrastructure — is
+ * never called.
+ */
+public class LocalDPoPCacheProviderTest {
+
+    private static final String KEY_ID = "test-proof-key-id";
+    private static final String JTI = "unique-jti-value";
+    private static final String JKT = "some-jwk-thumbprint";
+    private static final long TTL = 120L;
+
+    private LocalDPoPCacheProvider provider;
+    private DPoPJtiCache mockJtiCache;
+    private DPoPNonceCache mockNonceCache;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        provider = new LocalDPoPCacheProvider();
+        mockJtiCache = Mockito.mock(DPoPJtiCache.class);
+        mockNonceCache = Mockito.mock(DPoPNonceCache.class);
+        injectField(provider, "jtiCache", mockJtiCache);
+        injectField(provider, "nonceCache", mockNonceCache);
+    }
+
+    // ─── isJtiFirstUse ────────────────────────────────────────────────────────
+
+    @Test
+    public void isJtiFirstUseShouldReturnTrueOnFirstSeen() {
+        Mockito.when(mockJtiCache.isJtiFirstUse(JTI, JKT)).thenReturn(true);
+
+        boolean result = provider.isJtiFirstUse(JTI, JKT, TTL);
+
+        assertTrue(result);
+        Mockito.verify(mockJtiCache).isJtiFirstUse(JTI, JKT);
+    }
+
+    @Test
+    public void isJtiFirstUseShouldReturnFalseOnReplay() {
+        Mockito.when(mockJtiCache.isJtiFirstUse(JTI, JKT)).thenReturn(false);
+
+        boolean result = provider.isJtiFirstUse(JTI, JKT, TTL);
+
+        assertFalse(result);
+        Mockito.verify(mockJtiCache).isJtiFirstUse(JTI, JKT);
+    }
+
+    @Test
+    public void issueNonceShouldReturnNonBlankValue() {
+        String nonce = provider.issueNonce(KEY_ID);
+
+        assertNotNull(nonce);
+        assertFalse(StringUtils.isBlank(nonce));
+    }
+
+    @Test
+    public void issueNonceShouldCallNonceCacheStoreNonce() {
+        String nonce = provider.issueNonce(KEY_ID);
+
+        Mockito.verify(mockNonceCache).storeNonce(Mockito.eq(KEY_ID), Mockito.eq(nonce));
+    }
+
+    @Test
+    public void consecutiveIssueNonceCallsShouldReturnDifferentValues() {
+        String first = provider.issueNonce(KEY_ID);
+        String second = provider.issueNonce(KEY_ID);
+
+        assertNotEquals(first, second,
+                "Two consecutive nonces for the same key should differ (SecureRandom-backed)");
+    }
+
+    @Test
+    public void getActiveNonceShouldDelegateToNonceCache() {
+        String expected = "active-nonce-value";
+        Mockito.when(mockNonceCache.getActiveNonce(KEY_ID)).thenReturn(expected);
+
+        String result = provider.getActiveNonce(KEY_ID);
+
+        Mockito.verify(mockNonceCache).getActiveNonce(KEY_ID);
+        org.testng.Assert.assertEquals(result, expected);
+    }
+
+    @Test
+    public void getActiveNonceShouldReturnNullWhenNoneIssued() {
+        Mockito.when(mockNonceCache.getActiveNonce(KEY_ID)).thenReturn(null);
+
+        String result = provider.getActiveNonce(KEY_ID);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void isNonceValidAndConsumedShouldReturnFalseForNullNonce() {
+        boolean result = provider.isNonceValidAndConsumed(KEY_ID, null);
+
+        assertFalse(result);
+        Mockito.verify(mockNonceCache, Mockito.never())
+                .isNonceValidAndConsumed(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void isNonceValidAndConsumedShouldReturnTrueOnValidMatch() {
+        String nonce = "correct-nonce";
+        Mockito.when(mockNonceCache.isNonceValidAndConsumed(KEY_ID, nonce)).thenReturn(true);
+
+        boolean result = provider.isNonceValidAndConsumed(KEY_ID, nonce);
+
+        assertTrue(result);
+        Mockito.verify(mockNonceCache).isNonceValidAndConsumed(KEY_ID, nonce);
+    }
+
+    @Test
+    public void isNonceValidAndConsumedShouldReturnFalseOnMismatch() {
+        String nonce = "wrong-nonce";
+        Mockito.when(mockNonceCache.isNonceValidAndConsumed(KEY_ID, nonce)).thenReturn(false);
+
+        boolean result = provider.isNonceValidAndConsumed(KEY_ID, nonce);
+
+        assertFalse(result);
+        Mockito.verify(mockNonceCache).isNonceValidAndConsumed(KEY_ID, nonce);
+    }
+
+    @Test
+    public void initializeShouldCreateCachesWithProvidedTtl() {
+        try (MockedConstruction<DPoPJtiCache> jtiCons = Mockito.mockConstruction(DPoPJtiCache.class);
+             MockedConstruction<DPoPNonceCache> nonceCons = Mockito.mockConstruction(DPoPNonceCache.class)) {
+
+            Map<String, Object> props = new HashMap<>();
+            props.put("JtiCacheTtlSeconds", "180");
+            props.put("NonceTtlSeconds", "600");
+
+            new LocalDPoPCacheProvider().initialize(props);
+
+            org.testng.Assert.assertEquals(jtiCons.constructed().size(), 1);
+            org.testng.Assert.assertEquals(nonceCons.constructed().size(), 1);
+        }
+    }
+
+    @Test
+    public void initializeShouldUseDefaultsWhenPropertiesAbsent() {
+        try (MockedConstruction<DPoPJtiCache> jtiCons = Mockito.mockConstruction(DPoPJtiCache.class);
+             MockedConstruction<DPoPNonceCache> nonceCons = Mockito.mockConstruction(DPoPNonceCache.class)) {
+
+            new LocalDPoPCacheProvider().initialize(new HashMap<>());
+
+            org.testng.Assert.assertEquals(jtiCons.constructed().size(), 1);
+            org.testng.Assert.assertEquals(nonceCons.constructed().size(), 1);
+        }
+    }
+
+    @Test
+    public void initializeShouldFallbackToDefaultForInvalidTtlValue() {
+        try (MockedConstruction<DPoPJtiCache> jtiCons = Mockito.mockConstruction(DPoPJtiCache.class);
+             MockedConstruction<DPoPNonceCache> ignored = Mockito.mockConstruction(DPoPNonceCache.class)) {
+
+            Map<String, Object> props = new HashMap<>();
+            props.put("JtiCacheTtlSeconds", "not-a-number");
+
+            new LocalDPoPCacheProvider().initialize(props);
+
+            org.testng.Assert.assertEquals(jtiCons.constructed().size(), 1);
+        }
+    }
+
+    private static void injectField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/LocalDPoPCacheProviderTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/cache/LocalDPoPCacheProviderTest.java
@@ -127,37 +127,6 @@ public class LocalDPoPCacheProviderTest {
     }
 
     @Test
-    public void isNonceValidAndConsumedShouldReturnFalseForNullNonce() {
-        boolean result = provider.isNonceValidAndConsumed(KEY_ID, null);
-
-        assertFalse(result);
-        Mockito.verify(mockNonceCache, Mockito.never())
-                .isNonceValidAndConsumed(Mockito.any(), Mockito.any());
-    }
-
-    @Test
-    public void isNonceValidAndConsumedShouldReturnTrueOnValidMatch() {
-        String nonce = "correct-nonce";
-        Mockito.when(mockNonceCache.isNonceValidAndConsumed(KEY_ID, nonce)).thenReturn(true);
-
-        boolean result = provider.isNonceValidAndConsumed(KEY_ID, nonce);
-
-        assertTrue(result);
-        Mockito.verify(mockNonceCache).isNonceValidAndConsumed(KEY_ID, nonce);
-    }
-
-    @Test
-    public void isNonceValidAndConsumedShouldReturnFalseOnMismatch() {
-        String nonce = "wrong-nonce";
-        Mockito.when(mockNonceCache.isNonceValidAndConsumed(KEY_ID, nonce)).thenReturn(false);
-
-        boolean result = provider.isNonceValidAndConsumed(KEY_ID, nonce);
-
-        assertFalse(result);
-        Mockito.verify(mockNonceCache).isNonceValidAndConsumed(KEY_ID, nonce);
-    }
-
-    @Test
     public void initializeShouldCreateCachesWithProvidedTtl() {
         try (MockedConstruction<DPoPJtiCache> jtiCons = Mockito.mockConstruction(DPoPJtiCache.class);
              MockedConstruction<DPoPNonceCache> nonceCons = Mockito.mockConstruction(DPoPNonceCache.class)) {

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategyTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategyTest.java
@@ -38,6 +38,12 @@ public class NonceStrategyTest {
     }
 
     @Test
+    public void neverStrategyShouldNeverRotate() {
+        NeverNonceStrategy strategy = new NeverNonceStrategy();
+        assertFalse(strategy.shouldRotate("any-client"));
+    }
+
+    @Test
     public void alwaysStrategyShouldAlwaysRequireNonce() {
         AlwaysNonceStrategy strategy = new AlwaysNonceStrategy();
         assertTrue(strategy.requiresNonce("client-1"));
@@ -46,36 +52,40 @@ public class NonceStrategyTest {
     }
 
     @Test
-    public void rotatingStrategyShouldRequireNonceOnFirstAndEveryN() {
-        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3);
-        String client = "client-x";
-
-        assertTrue(strategy.requiresNonce(client));   // count=1 (first use)
-        assertFalse(strategy.requiresNonce(client));  // count=2
-        assertTrue(strategy.requiresNonce(client));   // count=3 (3%3==0)
-        assertFalse(strategy.requiresNonce(client));  // count=4
+    public void alwaysStrategyShouldNeverRotate() {
+        AlwaysNonceStrategy strategy = new AlwaysNonceStrategy();
+        assertFalse(strategy.shouldRotate("client-1"));
     }
 
     @Test
-    public void rotatingStrategyShouldRequireNonceAtModuloIntervals() {
-        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3);
-        String client = "client-y";
-
+    public void rotatingStrategyShouldAlwaysRequireNonce() {
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3, 10_000);
+        String client = "client-x";
         assertTrue(strategy.requiresNonce(client));
-        assertFalse(strategy.requiresNonce(client));
-        assertTrue(strategy.requiresNonce(client));   // count=3
-        assertFalse(strategy.requiresNonce(client));
-        assertFalse(strategy.requiresNonce(client));
-        assertTrue(strategy.requiresNonce(client));   // count=6
+        assertTrue(strategy.requiresNonce(client));
+        assertTrue(strategy.requiresNonce(client));
+        assertTrue(strategy.requiresNonce(client));
         assertEquals(strategy.getName(), "rotating");
+    }
+
+    @Test
+    public void rotatingStrategyShouldRotateAtModuloIntervals() {
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3, 10_000);
+        String client = "client-y";
+        assertFalse(strategy.shouldRotate(client)); // count=1
+        assertFalse(strategy.shouldRotate(client)); // count=2
+        assertTrue(strategy.shouldRotate(client));  // count=3 → 3%3==0
+        assertFalse(strategy.shouldRotate(client)); // count=4
+        assertFalse(strategy.shouldRotate(client)); // count=5
+        assertTrue(strategy.shouldRotate(client));  // count=6 → 6%3==0
     }
 
     @Test
     public void rotatingStrategyShouldFloorRotateAfterUsesAtOne() {
         // A misconfiguration of 0 or negative must not cause a div-by-zero in the strategy.
-        RotatingNonceStrategy strategy = new RotatingNonceStrategy(0);
-        assertTrue(strategy.requiresNonce("c"));
-        assertTrue(strategy.requiresNonce("c"));
-        assertTrue(strategy.requiresNonce("c"));
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(0, 10_000);
+        assertTrue(strategy.shouldRotate("c")); // count=1 → 1%1==0
+        assertTrue(strategy.shouldRotate("c")); // count=2 → 2%1==0
+        assertTrue(strategy.shouldRotate("c")); // count=3 → 3%1==0
     }
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategyTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/nonce/NonceStrategyTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.nonce;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for the three built-in {@link NonceStrategy} implementations.
+ */
+public class NonceStrategyTest {
+
+    @Test
+    public void neverStrategyShouldNeverRequireNonce() {
+        NeverNonceStrategy strategy = new NeverNonceStrategy();
+        assertFalse(strategy.requiresNonce("any-client"));
+        assertFalse(strategy.requiresNonce("any-client"));
+        assertEquals(strategy.getName(), "never");
+    }
+
+    @Test
+    public void alwaysStrategyShouldAlwaysRequireNonce() {
+        AlwaysNonceStrategy strategy = new AlwaysNonceStrategy();
+        assertTrue(strategy.requiresNonce("client-1"));
+        assertTrue(strategy.requiresNonce("client-2"));
+        assertEquals(strategy.getName(), "always");
+    }
+
+    @Test
+    public void rotatingStrategyShouldRequireNonceOnFirstAndEveryN() {
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3);
+        String client = "client-x";
+
+        assertTrue(strategy.requiresNonce(client));   // count=1 (first use)
+        assertFalse(strategy.requiresNonce(client));  // count=2
+        assertTrue(strategy.requiresNonce(client));   // count=3 (3%3==0)
+        assertFalse(strategy.requiresNonce(client));  // count=4
+    }
+
+    @Test
+    public void rotatingStrategyShouldRequireNonceAtModuloIntervals() {
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3);
+        String client = "client-y";
+
+        assertTrue(strategy.requiresNonce(client));
+        assertFalse(strategy.requiresNonce(client));
+        assertTrue(strategy.requiresNonce(client));   // count=3
+        assertFalse(strategy.requiresNonce(client));
+        assertFalse(strategy.requiresNonce(client));
+        assertTrue(strategy.requiresNonce(client));   // count=6
+        assertEquals(strategy.getName(), "rotating");
+    }
+
+    @Test
+    public void rotatingStrategyShouldFloorRotateAfterUsesAtOne() {
+        // A misconfiguration of 0 or negative must not cause a div-by-zero in the strategy.
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(0);
+        assertTrue(strategy.requiresNonce("c"));
+        assertTrue(strategy.requiresNonce("c"));
+        assertTrue(strategy.requiresNonce("c"));
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/proof/DPoPProofValidatorTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/proof/DPoPProofValidatorTest.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.proof;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.DPOP_JWT_TYPE;
+import static org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants.SHA256_HASH_ALG;
+import static org.wso2.financial.services.accelerator.gateway.util.GatewayConstants.GET_HTTP_METHOD;
+
+/**
+ * Unit tests for {@link DPoPProofValidator}. Exercises each RFC 9449 §4.3
+ * validation rule independently with both valid and invalid inputs.
+ */
+public class DPoPProofValidatorTest {
+
+    private static final Set<String> ACCEPTED_ALGS = new HashSet<>(Arrays.asList("ES256", "PS256"));
+    private static final long IAT_SKEW_SECONDS = 60L;
+    private static final String HTU = "https://api.example.com/resource";
+
+    private DPoPProofValidator validator;
+    private ECKey ecKey;
+    private String accessToken;
+    private String correctAth;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        validator = new DPoPProofValidator(ACCEPTED_ALGS, IAT_SKEW_SECONDS);
+        ecKey = new ECKeyGenerator(Curve.P_256).generate();
+        accessToken = "test.access.token";
+        correctAth = computeAth(accessToken);
+    }
+
+    @Test
+    public void validProofShouldSucceed() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        DPoPProofValidator.ValidationResult result = validator.validate(parsed, GET_HTTP_METHOD,
+                HTU, accessToken, null);
+        assertNotNull(result.getProofJkt());
+        assertNotNull(result.getJti());
+    }
+
+    @Test
+    public void validProofWithNonceShouldSucceed() throws Exception {
+        String nonce = "server-issued-nonce-123";
+        String proof = buildProof(ecKey, "POST", "https://api.example.com/data",
+                new Date(), UUID.randomUUID().toString(), correctAth, nonce);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        DPoPProofValidator.ValidationResult result = validator.validate(parsed, "POST",
+                "https://api.example.com/data", accessToken, nonce);
+        assertNotNull(result.getProofJkt());
+    }
+
+    @Test
+    public void missingProofShouldFail() {
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.parseDPoPProof(null));
+    }
+
+    @Test
+    public void wrongTypShouldFail() throws Exception {
+        ECKey key = new ECKeyGenerator(Curve.P_256).generate();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(new JOSEObjectType("JWT"))
+                .jwk(key.toPublicJWK())
+                .build();
+        String proof = signProof(key, header,
+                buildBasicClaims(GET_HTTP_METHOD, "https://example.com", new Date(),
+                        UUID.randomUUID().toString(), correctAth, null));
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, "https://example.com", accessToken, null));
+    }
+
+    @Test
+    public void unparseableProofShouldFail() {
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.parseDPoPProof("notajwt"));
+    }
+
+    @Test
+    public void unknownAlgorithmShouldFail() throws Exception {
+        RSAKey rsaKey = new RSAKeyGenerator(2048).generate();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .type(new JOSEObjectType(DPOP_JWT_TYPE))
+                .jwk(rsaKey.toPublicJWK())
+                .build();
+        JWTClaimsSet claims = buildBasicClaims(GET_HTTP_METHOD, "https://example.com",
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new RSASSASigner(rsaKey));
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(jwt.serialize());
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, "https://example.com", accessToken, null));
+    }
+
+    @Test
+    public void wrongHtmShouldFail() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, "POST", HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void wrongHtuShouldFail() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, "https://api.example.com/other",
+                        accessToken, null));
+    }
+
+    @Test
+    public void expiredIatShouldFail() throws Exception {
+        Date expiredIat = new Date(System.currentTimeMillis() - (IAT_SKEW_SECONDS + 5) * 1000L);
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                expiredIat, UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void futureIatBeyondSkewShouldFail() throws Exception {
+        Date futureIat = new Date(System.currentTimeMillis() + (IAT_SKEW_SECONDS + 5) * 1000L);
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                futureIat, UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void wrongAthShouldFail() throws Exception {
+        String wrongAth = computeAth("different.access.token");
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), wrongAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void missingAthWhenTokenPresentShouldFail() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), null, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void wrongNonceShouldReturnUseNonceError() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, "wrong-nonce");
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, "correct-nonce"));
+    }
+
+    @Test
+    public void missingNonceWhenRequiredShouldReturnUseNonceError() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, "required-nonce"));
+    }
+
+    @Test
+    public void htuTrailingSlashShouldBeNormalized() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, "https://api.example.com/resource/",
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        DPoPProofValidator.ValidationResult result = validator.validate(parsed, GET_HTTP_METHOD,
+                HTU, accessToken, null);
+        assertNotNull(result.getProofJkt());
+    }
+
+    @Test
+    public void proofWithNullHtuShouldFail() throws Exception {
+        // Passing null as htu omits the claim, triggering the null branch in normalizedUriEquals
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, null,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD,
+                        HTU, accessToken, null));
+    }
+
+    @Test
+    public void proofWithMissingJtiShouldFail() throws Exception {
+        // Pass null jti so the jti claim is absent from the proof
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), null, correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD,
+                        HTU, accessToken, null));
+    }
+
+    @Test
+    public void parseDPoPProofShouldPopulateKidWhenJwkHasKid() throws Exception {
+        ECKey keyWithKid = new ECKeyGenerator(Curve.P_256).keyID("my-key-id").generate();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(new JOSEObjectType(DPOP_JWT_TYPE))
+                .jwk(keyWithKid.toPublicJWK())
+                .build();
+        JWTClaimsSet claims = buildBasicClaims(GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(keyWithKid));
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(jwt.serialize());
+        assertEquals(parsed.getKid(), "my-key-id");
+    }
+
+    @Test
+    public void parseDPoPProofShouldReturnNullKidWhenJwkHasNoKid() throws Exception {
+        // ecKey (from setUp) was generated without a kid
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        org.testng.Assert.assertNull(parsed.getKid());
+    }
+
+    @Test
+    public void parsedProofShouldHaveNonNullJwkThumbprint() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertNotNull(parsed.getJwkThumbprint(),
+                "JWK thumbprint must be computed during parseDPoPProof");
+    }
+
+    private String buildProof(ECKey key, String htm, String htu, Date iat,
+                              String jti, String ath, String nonce) throws Exception {
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(new JOSEObjectType(DPOP_JWT_TYPE))
+                .jwk(key.toPublicJWK())
+                .build();
+        return signProof(key, header, buildBasicClaims(htm, htu, iat, jti, ath, nonce));
+    }
+
+    private JWTClaimsSet buildBasicClaims(String htm, String htu, Date iat,
+                                          String jti, String ath, String nonce) {
+        JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+                .jwtID(jti)
+                .claim(DPoPConstants.Claims.HTM_CLAIM, htm)
+                .claim(DPoPConstants.Claims.HTU_CLAIM, htu)
+                .issueTime(iat);
+        if (ath != null) {
+            builder.claim(DPoPConstants.Claims.ATH_CLAIM, ath);
+        }
+        if (nonce != null) {
+            builder.claim(DPoPConstants.Claims.NONCE_CLAIM, nonce);
+        }
+        return builder.build();
+    }
+
+    private String signProof(ECKey key, JWSHeader header, JWTClaimsSet claims) throws Exception {
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(key));
+        return jwt.serialize();
+    }
+
+    private String computeAth(String token) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance(SHA256_HASH_ALG);
+        byte[] hash = digest.digest(token.getBytes(StandardCharsets.US_ASCII));
+        return Base64URL.encode(hash).toString();
+    }
+
+    private void assertErrorCode(DPoPProofException.ErrorCode expected, ValidatorCall call) {
+        try {
+            call.execute();
+            fail("Expected DPoPProofException with error code " + expected);
+        } catch (DPoPProofException e) {
+            assertEquals(e.getErrorCode(), expected);
+        } catch (Exception e) {
+            fail("Unexpected exception type: " + e.getClass().getName() + ": " + e.getMessage());
+        }
+    }
+
+    @FunctionalInterface
+    interface ValidatorCall {
+        void execute() throws Exception;
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/util/ChallengeTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/util/ChallengeTest.java
@@ -23,6 +23,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.core.axis2.Axis2Sender;
 import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -49,17 +50,14 @@ public class ChallengeTest {
     private Challenge challenge;
     private Axis2MessageContext mockSynCtx;
     private MessageContext mockAxis2MC;
-    private Map<String, String> responseHeaders;
 
     @BeforeMethod
     public void setUp() {
         challenge = new Challenge(ACCEPTED_ALGS);
         mockSynCtx = Mockito.mock(Axis2MessageContext.class);
         mockAxis2MC = Mockito.mock(MessageContext.class);
-        responseHeaders = new HashMap<>();
 
         Mockito.when(mockSynCtx.getAxis2MessageContext()).thenReturn(mockAxis2MC);
-        Mockito.when(mockAxis2MC.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(responseHeaders);
     }
 
     @Test
@@ -75,12 +73,13 @@ public class ChallengeTest {
             challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
                     "Proof failed", null);
 
-            String wwwAuth = responseHeaders.get(HttpHeaders.WWW_AUTHENTICATE);
+            Map<String, String> headers = captureResponseHeaders();
+            String wwwAuth = headers.get(HttpHeaders.WWW_AUTHENTICATE);
             assertNotNull(wwwAuth, "WWW-Authenticate header must be set");
             assertTrue(wwwAuth.startsWith("DPoP"), "Challenge must start with 'DPoP'");
             assertTrue(wwwAuth.contains("error=\"invalid_dpop_proof\""),
                     "Challenge must contain the RFC error code");
-            assertFalse(responseHeaders.containsKey(HEADER_DPOP_NONCE),
+            assertFalse(headers.containsKey(HEADER_DPOP_NONCE),
                     "DPoP-Nonce header must not be present when no nonce is supplied");
         }
     }
@@ -100,11 +99,12 @@ public class ChallengeTest {
             challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.USE_DPOP_NONCE,
                     "Nonce required", nonce);
 
-            String dpopNonce = responseHeaders.get(HEADER_DPOP_NONCE);
+            Map<String, String> headers = captureResponseHeaders();
+            String dpopNonce = headers.get(HEADER_DPOP_NONCE);
             assertNotNull(dpopNonce, "DPoP-Nonce header must be set when a nonce is supplied");
             assertEquals(dpopNonce, nonce);
 
-            String wwwAuth = responseHeaders.get(HttpHeaders.WWW_AUTHENTICATE);
+            String wwwAuth = headers.get(HttpHeaders.WWW_AUTHENTICATE);
             assertNotNull(wwwAuth);
             assertTrue(wwwAuth.contains("error=\"use_dpop_nonce\""));
         }
@@ -120,11 +120,11 @@ public class ChallengeTest {
             senderStatic.when(() -> Axis2Sender.sendBack(mockSynCtx))
                     .thenAnswer(inv -> null);
 
-            // Should complete without NullPointerException
             challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
                     null, null);
 
-            String wwwAuth = responseHeaders.get(HttpHeaders.WWW_AUTHENTICATE);
+            Map<String, String> headers = captureResponseHeaders();
+            String wwwAuth = headers.get(HttpHeaders.WWW_AUTHENTICATE);
             assertNotNull(wwwAuth);
             assertTrue(wwwAuth.contains("error=\"invalid_dpop_proof\""));
             assertFalse(wwwAuth.contains("error_description"),
@@ -148,5 +148,50 @@ public class ChallengeTest {
             // Verify Axis2Sender.sendBack was called to dispatch the error response
             senderStatic.verify(() -> Axis2Sender.sendBack(mockSynCtx));
         }
+    }
+
+    @Test
+    public void send401ShouldNotEchoRequestHeadersInResponse() {
+        // Simulate what Synapse holds in TRANSPORT_HEADERS during handleRequest —
+        // the incoming client request headers.
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "DPoP <access-token>");
+        requestHeaders.put("DPoP", "<dpop-proof>");
+        requestHeaders.put("User-Agent", "PostmanRuntime/7.54.0");
+        requestHeaders.put("Host", "localhost:8243");
+        Mockito.when(mockAxis2MC.getProperty(MessageContext.TRANSPORT_HEADERS))
+                .thenReturn(requestHeaders);
+
+        try (MockedStatic<RelayUtils> relayStatic = Mockito.mockStatic(RelayUtils.class);
+             MockedStatic<Axis2Sender> senderStatic = Mockito.mockStatic(Axis2Sender.class)) {
+
+            relayStatic.when(() -> RelayUtils.consumeAndDiscardMessage(mockAxis2MC))
+                    .thenAnswer(inv -> null);
+            senderStatic.when(() -> Axis2Sender.sendBack(mockSynCtx))
+                    .thenAnswer(inv -> null);
+
+            challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "Proof failed", null);
+
+            Map<String, String> responseHeaders = captureResponseHeaders();
+            assertFalse(responseHeaders.containsKey("Authorization"),
+                    "Authorization request header must not appear in 401 response");
+            assertFalse(responseHeaders.containsKey("DPoP"),
+                    "DPoP request header must not appear in 401 response");
+            assertFalse(responseHeaders.containsKey("User-Agent"),
+                    "User-Agent request header must not appear in 401 response");
+            assertFalse(responseHeaders.containsKey("Host"),
+                    "Host request header must not appear in 401 response");
+            assertTrue(responseHeaders.containsKey(HttpHeaders.WWW_AUTHENTICATE),
+                    "WWW-Authenticate must still be present");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> captureResponseHeaders() {
+        ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(mockAxis2MC)
+                .setProperty(Mockito.eq(MessageContext.TRANSPORT_HEADERS), captor.capture());
+        return (Map<String, String>) captor.getValue();
     }
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/util/ChallengeTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/util/ChallengeTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.util;
+
+import org.apache.axis2.context.MessageContext;
+import org.apache.http.HttpHeaders;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.core.axis2.Axis2Sender;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link Challenge}. Uses {@code mockStatic} for
+ * {@link RelayUtils} and {@link Axis2Sender} to avoid real HTTP I/O.
+ */
+public class ChallengeTest {
+
+    private static final String ACCEPTED_ALGS = "ES256 PS256";
+    private static final String HEADER_DPOP_NONCE = "DPoP-Nonce";
+
+    private Challenge challenge;
+    private Axis2MessageContext mockSynCtx;
+    private MessageContext mockAxis2MC;
+    private Map<String, String> responseHeaders;
+
+    @BeforeMethod
+    public void setUp() {
+        challenge = new Challenge(ACCEPTED_ALGS);
+        mockSynCtx = Mockito.mock(Axis2MessageContext.class);
+        mockAxis2MC = Mockito.mock(MessageContext.class);
+        responseHeaders = new HashMap<>();
+
+        Mockito.when(mockSynCtx.getAxis2MessageContext()).thenReturn(mockAxis2MC);
+        Mockito.when(mockAxis2MC.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(responseHeaders);
+    }
+
+    @Test
+    public void send401WithInvalidDPoPProofShouldSetWwwAuthenticateHeader() {
+        try (MockedStatic<RelayUtils> relayStatic = Mockito.mockStatic(RelayUtils.class);
+             MockedStatic<Axis2Sender> senderStatic = Mockito.mockStatic(Axis2Sender.class)) {
+
+            relayStatic.when(() -> RelayUtils.consumeAndDiscardMessage(mockAxis2MC))
+                    .thenAnswer(inv -> null);
+            senderStatic.when(() -> Axis2Sender.sendBack(mockSynCtx))
+                    .thenAnswer(inv -> null);
+
+            challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "Proof failed", null);
+
+            String wwwAuth = responseHeaders.get(HttpHeaders.WWW_AUTHENTICATE);
+            assertNotNull(wwwAuth, "WWW-Authenticate header must be set");
+            assertTrue(wwwAuth.startsWith("DPoP"), "Challenge must start with 'DPoP'");
+            assertTrue(wwwAuth.contains("error=\"invalid_dpop_proof\""),
+                    "Challenge must contain the RFC error code");
+            assertFalse(responseHeaders.containsKey(HEADER_DPOP_NONCE),
+                    "DPoP-Nonce header must not be present when no nonce is supplied");
+        }
+    }
+
+    @Test
+    public void send401WithUseDPoPNonceShouldSetDPoPNonceHeader() {
+        String nonce = "server-issued-nonce-abc";
+
+        try (MockedStatic<RelayUtils> relayStatic = Mockito.mockStatic(RelayUtils.class);
+             MockedStatic<Axis2Sender> senderStatic = Mockito.mockStatic(Axis2Sender.class)) {
+
+            relayStatic.when(() -> RelayUtils.consumeAndDiscardMessage(mockAxis2MC))
+                    .thenAnswer(inv -> null);
+            senderStatic.when(() -> Axis2Sender.sendBack(mockSynCtx))
+                    .thenAnswer(inv -> null);
+
+            challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                    "Nonce required", nonce);
+
+            String dpopNonce = responseHeaders.get(HEADER_DPOP_NONCE);
+            assertNotNull(dpopNonce, "DPoP-Nonce header must be set when a nonce is supplied");
+            assertEquals(dpopNonce, nonce);
+
+            String wwwAuth = responseHeaders.get(HttpHeaders.WWW_AUTHENTICATE);
+            assertNotNull(wwwAuth);
+            assertTrue(wwwAuth.contains("error=\"use_dpop_nonce\""));
+        }
+    }
+
+    @Test
+    public void send401WithNullMessageShouldNotThrow() {
+        try (MockedStatic<RelayUtils> relayStatic = Mockito.mockStatic(RelayUtils.class);
+             MockedStatic<Axis2Sender> senderStatic = Mockito.mockStatic(Axis2Sender.class)) {
+
+            relayStatic.when(() -> RelayUtils.consumeAndDiscardMessage(mockAxis2MC))
+                    .thenAnswer(inv -> null);
+            senderStatic.when(() -> Axis2Sender.sendBack(mockSynCtx))
+                    .thenAnswer(inv -> null);
+
+            // Should complete without NullPointerException
+            challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    null, null);
+
+            String wwwAuth = responseHeaders.get(HttpHeaders.WWW_AUTHENTICATE);
+            assertNotNull(wwwAuth);
+            assertTrue(wwwAuth.contains("error=\"invalid_dpop_proof\""));
+            assertFalse(wwwAuth.contains("error_description"),
+                    "No error_description should be present for null message");
+        }
+    }
+
+    @Test
+    public void send401ShouldSet401StatusCodeOnSynCtx() {
+        try (MockedStatic<RelayUtils> relayStatic = Mockito.mockStatic(RelayUtils.class);
+             MockedStatic<Axis2Sender> senderStatic = Mockito.mockStatic(Axis2Sender.class)) {
+
+            relayStatic.when(() -> RelayUtils.consumeAndDiscardMessage(mockAxis2MC))
+                    .thenAnswer(inv -> null);
+            senderStatic.when(() -> Axis2Sender.sendBack(mockSynCtx))
+                    .thenAnswer(inv -> null);
+
+            challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "some error", null);
+
+            // Verify Axis2Sender.sendBack was called to dispatch the error response
+            senderStatic.verify(() -> Axis2Sender.sendBack(mockSynCtx));
+        }
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/util/DPoPUtilsTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/java/org/wso2/financial/services/accelerator/gateway/dpop/util/DPoPUtilsTest.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.financial.services.accelerator.gateway.dpop.util;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.axis2.context.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.nhttp.NhttpConstants;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.financial.services.accelerator.gateway.dpop.DPoPConstants;
+import org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Unit tests for {@link DPoPUtils} pure helpers and Synapse-context-dependent methods.
+ */
+public class DPoPUtilsTest {
+
+    private Axis2MessageContext mockSynCtx;
+    private MessageContext mockAxis2MC;
+
+    @BeforeMethod
+    public void setUp() {
+        mockSynCtx = Mockito.mock(Axis2MessageContext.class);
+        mockAxis2MC = Mockito.mock(MessageContext.class);
+        Mockito.when(mockSynCtx.getAxis2MessageContext()).thenReturn(mockAxis2MC);
+    }
+
+    @Test
+    public void parseBoolNullShouldReturnDefault() {
+        assertTrue(DPoPUtils.parseBool(null, true));
+        assertFalse(DPoPUtils.parseBool(null, false));
+    }
+
+    @Test
+    public void parseBoolLowercaseTrueShouldReturnTrue() {
+        assertTrue(DPoPUtils.parseBool("true", false));
+    }
+
+    @Test
+    public void parseBoolUppercaseTrueShouldReturnTrue() {
+        assertTrue(DPoPUtils.parseBool("TRUE", false));
+    }
+
+    @Test
+    public void parseBoolFalseShouldReturnFalse() {
+        assertFalse(DPoPUtils.parseBool("false", true));
+    }
+
+    @Test
+    public void parseBoolInvalidStringShouldReturnFalse() {
+        assertFalse(DPoPUtils.parseBool("invalid", false));
+        assertFalse(DPoPUtils.parseBool("yes", false));
+    }
+
+    @Test
+    public void parseLongNullShouldReturnDefault() {
+        assertEquals(DPoPUtils.parseLong(null, 42L), 42L);
+    }
+
+    @Test
+    public void parseLongValidNumberShouldReturnParsed() {
+        assertEquals(DPoPUtils.parseLong("120", 0L), 120L);
+    }
+
+    @Test
+    public void parseLongWhitespaceTrimmingNumber() {
+        assertEquals(DPoPUtils.parseLong("  300  ", 0L), 300L);
+    }
+
+    @Test
+    public void parseLongInvalidStringShouldReturnDefault() {
+        assertEquals(DPoPUtils.parseLong("abc", 99L), 99L);
+    }
+
+    @Test
+    public void parseStringNullShouldReturnDefault() {
+        assertEquals(DPoPUtils.parseString(null, "default"), "default");
+    }
+
+    @Test
+    public void parseStringBlankShouldReturnDefault() {
+        assertEquals(DPoPUtils.parseString("   ", "default"), "default");
+    }
+
+    @Test
+    public void parseStringValueShouldBeTrimmed() {
+        assertEquals(DPoPUtils.parseString("  value  ", "default"), "value");
+    }
+
+    @Test
+    public void parseAlgorithmsNullShouldReturnDefaultContainingES256() {
+        Set<String> algs = DPoPUtils.parseAlgorithms(null);
+        assertNotNull(algs);
+        assertTrue(algs.contains("ES256"), "Default algorithm set should contain ES256");
+    }
+
+    @Test
+    public void parseAlgorithmsBlankShouldReturnDefaultContainingES256() {
+        Set<String> algs = DPoPUtils.parseAlgorithms("  ");
+        assertTrue(algs.contains("ES256"));
+    }
+
+    @Test
+    public void parseAlgorithmsCommaSeparatedShouldReturnSetOfTwo() {
+        Set<String> algs = DPoPUtils.parseAlgorithms("ES256,PS256");
+        assertEquals(algs.size(), 2);
+        assertTrue(algs.contains("ES256"));
+        assertTrue(algs.contains("PS256"));
+    }
+
+    @Test
+    public void extractTokenNullHeaderShouldReturnNull() {
+        assertNull(DPoPUtils.extractToken(null, "Bearer"));
+    }
+
+    @Test
+    public void extractTokenBearerHeaderShouldReturnToken() {
+        assertEquals(DPoPUtils.extractToken("Bearer abc123", "Bearer"), "abc123");
+    }
+
+    @Test
+    public void extractTokenDPoPSchemeShouldReturnToken() {
+        assertEquals(DPoPUtils.extractToken("DPoP mytoken", "DPoP"), "mytoken");
+    }
+
+    @Test
+    public void extractTokenCaseInsensitiveSchemeShouldWork() {
+        assertEquals(DPoPUtils.extractToken("BEARER mytoken", "Bearer"), "mytoken");
+    }
+
+    @Test
+    public void extractTokenWrongSchemeShouldReturnNull() {
+        assertNull(DPoPUtils.extractToken("Basic dXNlcjpwYXNz", "Bearer"));
+    }
+
+    @Test
+    public void removeHeaderShouldRemoveExactMatch() {
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.put("Authorization", "Bearer token");
+        DPoPUtils.removeHeader(headers, "Authorization");
+        assertFalse(headers.containsKey("Authorization"));
+    }
+
+    @Test
+    public void removeHeaderShouldRemoveCaseVariants() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("authorization", "Bearer token1");
+        headers.put("AUTHORIZATION", "Bearer token2");
+        DPoPUtils.removeHeader(headers, "Authorization");
+        assertFalse(headers.containsKey("authorization"));
+        assertFalse(headers.containsKey("AUTHORIZATION"));
+    }
+
+    @Test
+    public void isJwtTokenNullShouldReturnFalse() {
+        assertFalse(DPoPUtils.isJwtToken(null));
+    }
+
+    @Test
+    public void isJwtTokenBlankShouldReturnFalse() {
+        assertFalse(DPoPUtils.isJwtToken(""));
+        assertFalse(DPoPUtils.isJwtToken("   "));
+    }
+
+    @Test
+    public void isJwtTokenThreePartShouldReturnTrue() {
+        assertTrue(DPoPUtils.isJwtToken("a.b.c"));
+    }
+
+    @Test
+    public void isJwtTokenTwoPartShouldReturnFalse() {
+        assertFalse(DPoPUtils.isJwtToken("a.b"));
+    }
+
+    @Test
+    public void isJwtTokenFourPartShouldReturnFalse() {
+        assertFalse(DPoPUtils.isJwtToken("a.b.c.d"));
+    }
+
+    @Test
+    public void extractJktFromJwtShouldReturnJktWhenPresent() throws Exception {
+        ECKey key = new ECKeyGenerator(Curve.P_256).generate();
+        String jkt = "expected-jkt-value";
+
+        Map<String, Object> cnf = new HashMap<>();
+        cnf.put(DPoPConstants.Claims.JKT_CLAIM, jkt);
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .claim(DPoPConstants.Claims.CNF_CLAIM, cnf)
+                .subject("client")
+                .build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(key));
+
+        String result = DPoPUtils.extractJktFromJwt(jwt.serialize());
+        assertEquals(result, jkt);
+    }
+
+    @Test
+    public void extractJktFromJwtWithoutCnfShouldReturnNull() throws Exception {
+        ECKey key = new ECKeyGenerator(Curve.P_256).generate();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder().subject("client").build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(key));
+
+        String result = DPoPUtils.extractJktFromJwt(jwt.serialize());
+        assertNull(result);
+    }
+
+    @Test
+    public void extractJktFromJwtNotAJwtShouldThrowDPoPProofException() {
+        try {
+            DPoPUtils.extractJktFromJwt("not.a.jwt");
+            fail("Expected DPoPProofException");
+        } catch (DPoPProofException e) {
+            assertEquals(e.getErrorCode(), DPoPProofException.ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    @Test
+    public void checkHttpsForHttpsUrlShouldNotThrow() throws DPoPProofException {
+        DPoPUtils.checkHttps("https://api.example.com/resource");
+    }
+
+    @Test
+    public void checkHttpsForHttpUrlShouldThrow() {
+        try {
+            DPoPUtils.checkHttps("http://api.example.com/resource");
+            fail("Expected DPoPProofException");
+        } catch (DPoPProofException e) {
+            assertEquals(e.getErrorCode(), DPoPProofException.ErrorCode.INVALID_DPOP_PROOF);
+        }
+    }
+
+    @Test
+    public void checkHttpsForNullShouldNotThrow() throws DPoPProofException {
+        DPoPUtils.checkHttps(null);
+    }
+
+    @Test
+    public void getTransportHeadersShouldReturnCaseInsensitiveMap() {
+        Map<String, String> rawHeaders = new HashMap<>();
+        rawHeaders.put("Authorization", "Bearer token");
+        rawHeaders.put("dpop", "proof-value");
+        Mockito.when(mockAxis2MC.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(rawHeaders);
+
+        Map<String, String> result = DPoPUtils.getTransportHeaders(mockSynCtx);
+
+        assertNotNull(result);
+        assertEquals(result.get("authorization"), "Bearer token");
+        assertEquals(result.get("AUTHORIZATION"), "Bearer token");
+        assertEquals(result.get("DPoP"), "proof-value");
+    }
+
+    @Test
+    public void getTransportHeadersNullPropertyShouldReturnEmptyMap() {
+        Mockito.when(mockAxis2MC.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(null);
+
+        Map<String, String> result = DPoPUtils.getTransportHeaders(mockSynCtx);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void normalizeHtuShouldBuildCorrectUri() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Host", "api.example.com");
+
+        Mockito.when(mockSynCtx.getProperty("TRANSPORT_IN_NAME")).thenReturn("https");
+        Mockito.when(mockSynCtx.getProperty("REST_FULL_REQUEST_PATH")).thenReturn("/resource");
+
+        String htu = DPoPUtils.normalizeHtu(mockSynCtx, headers);
+
+        assertEquals(htu, "https://api.example.com/resource");
+    }
+
+    @Test
+    public void hasMultipleDPopHeadersShouldReturnTrueWhenExcessContainsDPoP() {
+        Map<String, String> excessHeaders = new HashMap<>();
+        excessHeaders.put("DPoP", "second-proof-value");
+        Mockito.when(mockAxis2MC.getProperty(NhttpConstants.EXCESS_TRANSPORT_HEADERS))
+                .thenReturn(excessHeaders);
+
+        assertTrue(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx));
+    }
+
+    @Test
+    public void hasMultipleDPopHeadersShouldReturnFalseWhenExcessEmpty() {
+        Mockito.when(mockAxis2MC.getProperty(NhttpConstants.EXCESS_TRANSPORT_HEADERS))
+                .thenReturn(new HashMap<>());
+
+        assertFalse(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx));
+    }
+}

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/resources/testng.xml
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.gateway/src/test/resources/testng.xml
@@ -26,6 +26,14 @@
             <class name="org.wso2.financial.services.accelerator.gateway.executor.impl.error.handling.DefaultErrorHandlingExecutorTest" />
             <class name="org.wso2.financial.services.accelerator.gateway.executor.impl.dcr.DCRExecutorTest" />
             <class name="org.wso2.financial.services.accelerator.gateway.util.GatewayUtilsTest"/>
+            <class name="org.wso2.financial.services.accelerator.gateway.dpop.nonce.NonceStrategyTest"/>
+            <class name="org.wso2.financial.services.accelerator.gateway.dpop.proof.DPoPProofValidatorTest"/>
+            <class name="org.wso2.financial.services.accelerator.gateway.dpop.binding.AccessTokenBinderTest"/>
+            <class name="org.wso2.financial.services.accelerator.gateway.dpop.cache.LocalDPoPCacheProviderTest"/>
+            <class name="org.wso2.financial.services.accelerator.gateway.dpop.util.DPoPUtilsTest"/>
+            <class name="org.wso2.financial.services.accelerator.gateway.dpop.util.ChallengeTest"/>
+            <class name="org.wso2.financial.services.accelerator.gateway.dpop.binding.IntrospectionClientTest"/>
+            <class name="org.wso2.financial.services.accelerator.gateway.dpop.DPoPHandlerTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -525,6 +525,11 @@
                 <version>${org.wso2.carbon.apimgt.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.apimgt</groupId>
+                <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
+                <version>${org.wso2.carbon.apimgt.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.km.ext.wso2is</groupId>
                 <artifactId>wso2is7.key.manager</artifactId>
                 <version>${wso2.is7.key.manager.version}</version>


### PR DESCRIPTION
## Purpose
Adds a full DPoP (Demonstrating Proof of Possession, RFC 9449) implementation to the Financial Services Accelerator gateway module. The DPoPHandler is a Synapse handler that validates DPoP-bound access tokens and their proof JWTs
before they reach the downstream OAuth authenticator, enabling FAPI 2.0 compliant deployments.

**Issue link:** https://github.com/wso2/financial-services-accelerator/issues/953

**Doc Issue:** N/A

**Applicable Labels:** feature, gateway, security, fapi2.0, 4.0.0

------

### Changes

**`org.wso2.financial.services.accelerator.gateway`**
- `DPoPHandler` — Synapse handler that validates DPoP proofs per RFC 9449 §4.3 (signature, algorithm, `typ`, `htm`, `htu`, `iat`, `ath`, `jti`). Rewrites `Authorization: DPoP` to `Authorization: Bearer` after successful validation.
- `DPoPProofValidator` — Pure JOSE proof validation; parses proof JWTs once per request and exposes `ParsedProof` / `ValidationResult` value objects.
- `AccessTokenBinder` — Resolves `cnf.jkt` from JWT or opaque access tokens and verifies the binding against the proof's JWK thumbprint.
- `IntrospectionClient` — Wraps the APIM Key Manager introspection endpoint with an in-memory result cache to avoid repeated round-trips for the same token.
- `DPoPCacheProvider` SPI + `LocalDPoPCacheProvider` — JTI replay-defense set and nonce store backed by the Carbon cache infrastructure. Distributed deployments can plug in a custom implementation via `CacheProviderClass`.
- `AlwaysNonceStrategy`, `NeverNonceStrategy`, `RotatingNonceStrategy` — Three built-in nonce enforcement policies configurable via `financial-services.xml`.
- `Challenge` — Builds the RFC 9449 §7.1 `WWW-Authenticate: DPoP` challenge and sends the 401 response.

**`org.wso2.financial.services.accelerator.common`**
- `FinancialServicesBaseCache` — Added atomic `addToCacheIfAbsent` and `removeFromCacheIfMatch` operations (JSR-107 `putIfAbsent` / `remove(k,v)`) required for race-free JTI replay detection and nonce consumption.

**Configuration**
- `financial-services.xml.j2` — New `<Gateway><DPoP>` section with all configurable knobs: `Enabled`, `AcceptedAlgorithms`, `IatSkewSeconds`,`JtiCacheTtlSeconds`, `NonceStrategy`, `NonceTtlSeconds`, `HttpsRequired`,
  `StripDpopHeader`, `IntrospectionCacheTtlSeconds`, `CacheProviderClass`.
- APIM deployment TOML files updated for 4.4.0, 4.5.0, and 4.6.0.

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable). — N/A (new feature)
8. [x] Have you followed secure coding standards in WSO2 Secure Engineering Guidelines?

### Testing Checklist

1. [x] Written unit tests. — New test classes covering DPoPHandler, DPoPProofValidator,
   AccessTokenBinder, IntrospectionClient, LocalDPoPCacheProvider, Challenge,
   DPoPUtils, and all nonce strategies. Coverage ≥ 80%.
2. [ ] Verified tests in multiple database environments (if applicable). — N/A
3. [ ] Tested with BI enabled (if applicable). — N/A