### PR TITLE
fix(ci): ensure PR code is built on pull_request_target workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@
 name: Build Financial Services Repository
 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on pull request events but only for the main branch
   pull_request_target:
     branches:
       - 'main'
@@ -34,13 +34,14 @@ jobs:
       TEST_HOME: /home/runner/work/financial-services/financial-services
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Adopt JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: 11.0.25+9
           distribution: 'temurin'
-      - uses: actions/checkout@v3
       - name: Set up Node 16
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Summary

- The `pull_request_target` trigger was checking out the base branch (`main`) instead of the PR's changes, meaning every PR build silently tested `main` regardless of what the PR contained
- Added `ref: ${{ github.event.pull_request.head.sha }}` to the checkout step so the actual PR code is built
- Removed the duplicate `actions/checkout@v2` step (was immediately overwritten by the `@v3` step below it)
- Fixed stale comment referencing "master" instead of "main"

## Test plan

- [ ] Open a PR targeting `main` and verify the workflow runs against the PR's changes
- [ ] Confirm the workflow still has access to repository secrets (required for integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)