### PR TITLE
fix(checkstyle): fix line length violation in FSAdditionalAttributeFilter

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.identity.extensions/src/main/java/org/wso2/financial/services/accelerator/identity/extensions/client/registration/dcr/attribute/filter/FSAdditionalAttributeFilter.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.identity.extensions/src/main/java/org/wso2/financial/services/accelerator/identity/extensions/client/registration/dcr/attribute/filter/FSAdditionalAttributeFilter.java
@@ -159,7 +159,7 @@ public class FSAdditionalAttributeFilter implements AdditionalAttributeFilter {
      * @throws DCRMClientException    DCRM Client Exception
      */
     private Map<String, Object> handleGatewayDCRRegisterRequest(ApplicationRegistrationRequest appRegistrationRequest,
-                                                                Map<String, Object> ssaParams) throws DCRMClientException {
+            Map<String, Object> ssaParams) throws DCRMClientException {
         // Executing configured DCR validators.
         for (DynamicClientRegistrationValidator validator : DCRUtils.getEnabledDcrValidators()) {
             try {


### PR DESCRIPTION
## Summary

- Reformatted the continuation line of `handleGatewayDCRRegisterRequest` method signature in `FSAdditionalAttributeFilter.java` to stay within the 120-character checkstyle limit
- Line 162 was 123 characters; reduced to 69 characters by using standard 8-space continuation indent instead of paren-aligned indent

## Test plan

- [ ] Verify the Maven build passes the checkstyle audit for `org.wso2.financial.services.accelerator.identity.extensions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)