### PR TITLE
[OB3] Add DPoP (RFC 9449) proof-of-possession validation to the Open Banking Gateway

### DIFF
--- a/open-banking-accelerator/accelerators/ob-apim/carbon-home/repository/resources/conf/templates/repository/conf/open-banking.xml.j2
+++ b/open-banking-accelerator/accelerators/ob-apim/carbon-home/repository/resources/conf/templates/repository/conf/open-banking.xml.j2
@@ -213,6 +213,39 @@
             	</AllowedScopes>
 
             </TPPManagement>
+
+            <DPoP>
+                {% if open_banking.gateway.dpop.accepted_algorithms is defined %}
+                <AcceptedAlgorithms>{{open_banking.gateway.dpop.accepted_algorithms}}</AcceptedAlgorithms>
+                {% endif %}
+                {% if open_banking.gateway.dpop.iat_skew_seconds is defined %}
+                <IatSkewSeconds>{{open_banking.gateway.dpop.iat_skew_seconds}}</IatSkewSeconds>
+                {% endif %}
+                {% if open_banking.gateway.dpop.jti_cache_ttl_seconds is defined %}
+                <JtiCacheTtlSeconds>{{open_banking.gateway.dpop.jti_cache_ttl_seconds}}</JtiCacheTtlSeconds>
+                {% endif %}
+                {% if open_banking.gateway.dpop.nonce_strategy is defined %}
+                <NonceStrategy>{{open_banking.gateway.dpop.nonce_strategy}}</NonceStrategy>
+                {% endif %}
+                {% if open_banking.gateway.dpop.nonce_ttl_seconds is defined %}
+                <NonceTtlSeconds>{{open_banking.gateway.dpop.nonce_ttl_seconds}}</NonceTtlSeconds>
+                {% endif %}
+                {% if open_banking.gateway.dpop.nonce_rotate_after_uses is defined %}
+                <NonceRotateAfterUses>{{open_banking.gateway.dpop.nonce_rotate_after_uses}}</NonceRotateAfterUses>
+                {% endif %}
+                {% if open_banking.gateway.dpop.https_required is defined %}
+                <HttpsRequired>{{open_banking.gateway.dpop.https_required}}</HttpsRequired>
+                {% endif %}
+                {% if open_banking.gateway.dpop.strip_dpop_header is defined %}
+                <StripDpopHeader>{{open_banking.gateway.dpop.strip_dpop_header}}</StripDpopHeader>
+                {% endif %}
+                {% if open_banking.gateway.dpop.introspection_cache_ttl_seconds is defined %}
+                <IntrospectionCacheTtlSeconds>{{open_banking.gateway.dpop.introspection_cache_ttl_seconds}}</IntrospectionCacheTtlSeconds>
+                {% endif %}
+                {% if open_banking.gateway.dpop.cache_provider_class is defined %}
+                <CacheProviderClass>{{open_banking.gateway.dpop.cache_provider_class}}</CacheProviderClass>
+                {% endif %}
+            </DPoP>
     </Gateway>
     <DCR>
         <APIMRESTEndPoints>

--- a/open-banking-accelerator/accelerators/ob-apim/carbon-home/repository/resources/conf/templates/repository/conf/open-banking.xml.j2
+++ b/open-banking-accelerator/accelerators/ob-apim/carbon-home/repository/resources/conf/templates/repository/conf/open-banking.xml.j2
@@ -233,6 +233,9 @@
                 {% if open_banking.gateway.dpop.nonce_rotate_after_uses is defined %}
                 <NonceRotateAfterUses>{{open_banking.gateway.dpop.nonce_rotate_after_uses}}</NonceRotateAfterUses>
                 {% endif %}
+                {% if open_banking.gateway.dpop.nonce_max_tracked_clients is defined %}
+                <NonceMaxTrackedClients>{{open_banking.gateway.dpop.nonce_max_tracked_clients}}</NonceMaxTrackedClients>
+                {% endif %}
                 {% if open_banking.gateway.dpop.https_required is defined %}
                 <HttpsRequired>{{open_banking.gateway.dpop.https_required}}</HttpsRequired>
                 {% endif %}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.common/src/main/java/com/wso2/openbanking/accelerator/common/caching/OpenBankingBaseCache.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.common/src/main/java/com/wso2/openbanking/accelerator/common/caching/OpenBankingBaseCache.java
@@ -194,6 +194,44 @@ public abstract class OpenBankingBaseCache<K extends OpenBankingBaseCacheKey, V>
 
     }
 
+    /**
+     * Add to cache only if the key is not already present. The check and insert are
+     * performed as a single atomic operation by the underlying JSR-107 provider.
+     * Returns {@code true} if the value was stored, {@code false} if the key already existed.
+     *
+     * @param key   cache key.
+     * @param value cache value.
+     * @return true if the entry was inserted, false if it already existed.
+     */
+    public boolean addToCacheIfAbsent(K key, V value) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Attempting addIfAbsent for `%s` in cache %s",
+                    key.toString().replaceAll("[\r\n]", ""), cacheName.replaceAll("[\r\n]", "")));
+        }
+
+        return getBaseCache().putIfAbsent(key, value);
+    }
+
+    /**
+     * Remove from cache only if the entry is currently mapped to the expected value.
+     * The check and removal are performed as a single atomic operation by the underlying
+     * JSR-107 provider. Returns {@code true} if the entry was removed, {@code false} if
+     * the key was absent or mapped to a different value.
+     *
+     * @param key           cache key.
+     * @param expectedValue the value that must be present for the removal to proceed.
+     * @return true if the entry was removed, false otherwise.
+     */
+    public boolean removeFromCacheIfMatch(K key, V expectedValue) {
+
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Attempting conditional remove for `%s` in cache %s",
+                    key.toString().replaceAll("[\r\n]", ""), cacheName.replaceAll("[\r\n]", "")));
+        }
+
+        return getBaseCache().remove(key, expectedValue);
+    }
 
     /**
      * Get Cache expiry time upon access in minutes.

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/pom.xml
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/pom.xml
@@ -114,6 +114,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
         </dependency>

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPConstants.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPConstants.java
@@ -79,6 +79,7 @@ public final class DPoPConstants {
         public static final String NONCE_STRATEGY = GATEWAY_DPOP_PREFIX + "NonceStrategy";
         public static final String NONCE_TTL_SECONDS = GATEWAY_DPOP_PREFIX + "NonceTtlSeconds";
         public static final String NONCE_ROTATE_AFTER_USES = GATEWAY_DPOP_PREFIX + "NonceRotateAfterUses";
+        public static final String NONCE_MAX_TRACKED_CLIENTS = GATEWAY_DPOP_PREFIX + "NonceMaxTrackedClients";
         public static final String HTTPS_REQUIRED = GATEWAY_DPOP_PREFIX + "HttpsRequired";
         public static final String STRIP_DPOP_HEADER = GATEWAY_DPOP_PREFIX + "StripDpopHeader";
         public static final String INTROSPECTION_CACHE_TTL_SECONDS =
@@ -100,6 +101,7 @@ public final class DPoPConstants {
         public static final String NONCE_STRATEGY = "never";
         public static final long NONCE_TTL_SECONDS = 300L;
         public static final int NONCE_ROTATE_AFTER_USES = 10;
+        public static final int NONCE_MAX_TRACKED_CLIENTS = 10_000;
         public static final boolean HTTPS_REQUIRED = true;
         public static final boolean STRIP_DPOP_HEADER = false;
         public static final long INTROSPECTION_CACHE_TTL_SECONDS = 60L;

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPConstants.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPConstants.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop;
+
+import static com.wso2.openbanking.accelerator.gateway.util.GatewayConstants.BEARER_TAG;
+
+/**
+ * RFC 9449 claim names and {@code open-banking.xml} configuration keys
+ * consumed by the DPoP module.
+ */
+public final class DPoPConstants {
+
+    private DPoPConstants() {
+    }
+
+    public static final String DPOP_HEADER = "DPoP";
+    public static final String DPOP_SCHEME = "DPoP";
+    public static final String DPOP_NONCE_HEADER = "DPoP-Nonce";
+
+    public static final String DPOP_JWT_TYPE = "dpop+jwt";
+    public static final String SHA256_HASH_ALG = "SHA-256";
+
+    public static final int DPOP_SCHEME_LEN = DPOP_SCHEME.length() + 1;
+    public static final int BEARER_SCHEME_LEN = BEARER_TAG.trim().length() + 1;
+
+    public static final String DPOP_BOUND_PROPERTY = "dpop.bound";
+    /** Synapse message property used to pass a rotated nonce from request to response handling. */
+    public static final String DPOP_RESPONSE_NONCE_PROPERTY = "dpop.response.nonce";
+
+    public static final String CACHE_CONTROL_NO_STORE = "no-store";
+
+    /**
+     * RFC 9449 §4.2 claim names.
+     */
+    public static final class Claims {
+
+        private Claims() {
+        }
+
+        public static final String CNF_CLAIM = "cnf";
+        public static final String JKT_CLAIM = "jkt";
+        public static final String JTI_CLAIM = "jti";
+        public static final String HTM_CLAIM = "htm";
+        public static final String HTU_CLAIM = "htu";
+        public static final String IAT_CLAIM = "iat";
+        public static final String ATH_CLAIM = "ath";
+        public static final String NONCE_CLAIM = "nonce";
+    }
+
+    /**
+     * Flattened keys under {@code <FinancialServices><Gateway><DPoP>...</DPoP></Gateway></FinancialServices>}
+     * as produced by {@code FinancialServicesConfigParser}.
+     */
+    public static final class ConfigKeys {
+
+        private ConfigKeys() {
+        }
+
+        public static final String GATEWAY_DPOP_PREFIX = "Gateway.DPoP.";
+        public static final String ACCEPTED_ALGORITHMS = GATEWAY_DPOP_PREFIX + "AcceptedAlgorithms";
+        public static final String IAT_SKEW_SECONDS = GATEWAY_DPOP_PREFIX + "IatSkewSeconds";
+        public static final String JTI_CACHE_TTL_SECONDS = GATEWAY_DPOP_PREFIX + "JtiCacheTtlSeconds";
+        public static final String NONCE_STRATEGY = GATEWAY_DPOP_PREFIX + "NonceStrategy";
+        public static final String NONCE_TTL_SECONDS = GATEWAY_DPOP_PREFIX + "NonceTtlSeconds";
+        public static final String NONCE_ROTATE_AFTER_USES = GATEWAY_DPOP_PREFIX + "NonceRotateAfterUses";
+        public static final String HTTPS_REQUIRED = GATEWAY_DPOP_PREFIX + "HttpsRequired";
+        public static final String STRIP_DPOP_HEADER = GATEWAY_DPOP_PREFIX + "StripDpopHeader";
+        public static final String INTROSPECTION_CACHE_TTL_SECONDS =
+                GATEWAY_DPOP_PREFIX + "IntrospectionCacheTtlSeconds";
+        public static final String CACHE_PROVIDER_CLASS = GATEWAY_DPOP_PREFIX + "CacheProviderClass";
+    }
+
+    /**
+     * Default values that apply when a key is absent from {@code open-banking.xml}.
+     */
+    public static final class Defaults {
+
+        private Defaults() {
+        }
+
+        public static final String ACCEPTED_ALGORITHMS = "ES256,ES384,ES512,PS256,PS384,PS512";
+        public static final long IAT_SKEW_SECONDS = 60L;
+        public static final long JTI_CACHE_TTL_SECONDS = 120L;
+        public static final String NONCE_STRATEGY = "never";
+        public static final long NONCE_TTL_SECONDS = 300L;
+        public static final int NONCE_ROTATE_AFTER_USES = 10;
+        public static final boolean HTTPS_REQUIRED = true;
+        public static final boolean STRIP_DPOP_HEADER = false;
+        public static final long INTROSPECTION_CACHE_TTL_SECONDS = 60L;
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandler.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandler.java
@@ -23,10 +23,8 @@ import com.wso2.openbanking.accelerator.gateway.dpop.binding.AccessTokenBinder;
 import com.wso2.openbanking.accelerator.gateway.dpop.binding.IntrospectionClient;
 import com.wso2.openbanking.accelerator.gateway.dpop.cache.DPoPCacheProvider;
 import com.wso2.openbanking.accelerator.gateway.dpop.cache.LocalDPoPCacheProvider;
-import com.wso2.openbanking.accelerator.gateway.dpop.nonce.AlwaysNonceStrategy;
-import com.wso2.openbanking.accelerator.gateway.dpop.nonce.NeverNonceStrategy;
 import com.wso2.openbanking.accelerator.gateway.dpop.nonce.NonceStrategy;
-import com.wso2.openbanking.accelerator.gateway.dpop.nonce.RotatingNonceStrategy;
+import com.wso2.openbanking.accelerator.gateway.dpop.nonce.NonceStrategyType;
 import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
 import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofValidator;
 import com.wso2.openbanking.accelerator.gateway.dpop.util.Challenge;
@@ -56,7 +54,6 @@ import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_S
 import static com.wso2.openbanking.accelerator.gateway.dpop.util.DPoPUtils.parseBool;
 import static com.wso2.openbanking.accelerator.gateway.util.GatewayConstants.AUTH_HEADER;
 import static com.wso2.openbanking.accelerator.gateway.util.GatewayConstants.BEARER_TAG;
-import static org.apache.commons.lang.StringUtils.equalsIgnoreCase;
 
 
 /**
@@ -120,7 +117,7 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
                 DPoPConstants.Defaults.INTROSPECTION_CACHE_TTL_SECONDS);
 
         this.proofValidator = new DPoPProofValidator(algorithms, iatSkewSeconds);
-        this.nonceStrategy = buildNonceStrategy(nonceStrategyName, nonceRotateAfterUses, nonceMaxTrackedClients);
+        this.nonceStrategy = this.buildNonceStrategy(nonceStrategyName, nonceRotateAfterUses, nonceMaxTrackedClients);
         this.accessTokenBinder = new AccessTokenBinder(new IntrospectionClient(introspectionTtl));
         this.challenge = new Challenge(String.join(" ", algorithms));
 
@@ -368,25 +365,20 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
     }
 
     /**
-     * Maps the configured nonce strategy name to its implementation. Throws
-     * {@link IllegalArgumentException} for unrecognised names to fail fast on misconfiguration
-     * rather than silently falling back to no-nonce enforcement.
+     * Maps the configured nonce strategy name to its implementation.
+     * Falls back to {@code never} for unrecognised names.
      */
     private NonceStrategy buildNonceStrategy(String name, int rotateAfterUses, int maxTrackedClients) {
+
         if (log.isDebugEnabled()) {
             log.debug(String.format("Building nonce strategy: name=%s, rotateAfterUses=%s, maxTrackedClients=%s",
                     name, rotateAfterUses, maxTrackedClients));
         }
-        if (equalsIgnoreCase("always", name)) {
-            return new AlwaysNonceStrategy();
-        }
-        if (equalsIgnoreCase("rotating", name)) {
-            return new RotatingNonceStrategy(rotateAfterUses, maxTrackedClients);
-        }
-        if (equalsIgnoreCase("never", name)) {
-            return new NeverNonceStrategy();
-        }
-        throw new IllegalArgumentException("Unsupported DPoP nonce strategy: " + name);
+        return NonceStrategyType.fromName(name)
+                .orElseGet(() -> {
+                    log.warn("Unsupported DPoP nonce strategy '" + name + "' - falling back to 'never'.");
+                    return NonceStrategyType.NEVER;
+                }).create(rotateAfterUses, maxTrackedClients);
     }
 
     /**

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandler.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandler.java
@@ -113,11 +113,14 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
                 DPoPConstants.Defaults.NONCE_STRATEGY);
         int nonceRotateAfterUses = (int) DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.NONCE_ROTATE_AFTER_USES),
                 DPoPConstants.Defaults.NONCE_ROTATE_AFTER_USES);
+        int nonceMaxTrackedClients = (int) DPoPUtils.parseLong(
+                cfg.get(DPoPConstants.ConfigKeys.NONCE_MAX_TRACKED_CLIENTS),
+                DPoPConstants.Defaults.NONCE_MAX_TRACKED_CLIENTS);
         long introspectionTtl = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.INTROSPECTION_CACHE_TTL_SECONDS),
                 DPoPConstants.Defaults.INTROSPECTION_CACHE_TTL_SECONDS);
 
         this.proofValidator = new DPoPProofValidator(algorithms, iatSkewSeconds);
-        this.nonceStrategy = buildNonceStrategy(nonceStrategyName, nonceRotateAfterUses);
+        this.nonceStrategy = buildNonceStrategy(nonceStrategyName, nonceRotateAfterUses, nonceMaxTrackedClients);
         this.accessTokenBinder = new AccessTokenBinder(new IntrospectionClient(introspectionTtl));
         this.challenge = new Challenge(String.join(" ", algorithms));
 
@@ -369,12 +372,16 @@ public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
      * {@link IllegalArgumentException} for unrecognised names to fail fast on misconfiguration
      * rather than silently falling back to no-nonce enforcement.
      */
-    private NonceStrategy buildNonceStrategy(String name, int rotateAfterUses) {
+    private NonceStrategy buildNonceStrategy(String name, int rotateAfterUses, int maxTrackedClients) {
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Building nonce strategy: name=%s, rotateAfterUses=%s, maxTrackedClients=%s",
+                    name, rotateAfterUses, maxTrackedClients));
+        }
         if (equalsIgnoreCase("always", name)) {
             return new AlwaysNonceStrategy();
         }
         if (equalsIgnoreCase("rotating", name)) {
-            return new RotatingNonceStrategy(rotateAfterUses);
+            return new RotatingNonceStrategy(rotateAfterUses, maxTrackedClients);
         }
         if (equalsIgnoreCase("never", name)) {
             return new NeverNonceStrategy();

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandler.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandler.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop;
+
+import com.wso2.openbanking.accelerator.common.util.OpenBankingUtils;
+import com.wso2.openbanking.accelerator.gateway.dpop.binding.AccessTokenBinder;
+import com.wso2.openbanking.accelerator.gateway.dpop.binding.IntrospectionClient;
+import com.wso2.openbanking.accelerator.gateway.dpop.cache.DPoPCacheProvider;
+import com.wso2.openbanking.accelerator.gateway.dpop.cache.LocalDPoPCacheProvider;
+import com.wso2.openbanking.accelerator.gateway.dpop.nonce.AlwaysNonceStrategy;
+import com.wso2.openbanking.accelerator.gateway.dpop.nonce.NeverNonceStrategy;
+import com.wso2.openbanking.accelerator.gateway.dpop.nonce.NonceStrategy;
+import com.wso2.openbanking.accelerator.gateway.dpop.nonce.RotatingNonceStrategy;
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofValidator;
+import com.wso2.openbanking.accelerator.gateway.dpop.util.Challenge;
+import com.wso2.openbanking.accelerator.gateway.dpop.util.DPoPUtils;
+import com.wso2.openbanking.accelerator.gateway.internal.GatewayDataHolder;
+import org.apache.axis2.Constants;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHeaders;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.rest.AbstractHandler;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.BEARER_SCHEME_LEN;
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_BOUND_PROPERTY;
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_HEADER;
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_SCHEME;
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_SCHEME_LEN;
+import static com.wso2.openbanking.accelerator.gateway.dpop.util.DPoPUtils.parseBool;
+import static com.wso2.openbanking.accelerator.gateway.util.GatewayConstants.AUTH_HEADER;
+import static com.wso2.openbanking.accelerator.gateway.util.GatewayConstants.BEARER_TAG;
+import static org.apache.commons.lang.StringUtils.equalsIgnoreCase;
+
+
+/**
+ * Custom Synapse handler that validates DPoP-bound access tokens per RFC 9449.
+ * <p>
+ * Must be positioned BEFORE the built-in {@code APIAuthenticationHandler} in
+ * {@code velocity_template.xml}. All tuning is read from {@code open-banking.xml}
+ * under {@code <Gateway><DPoP>...</DPoP></Gateway>}. DPoP enforcement is opt-in per API:
+ * set {@code apiDPoPEnabled=true} on each handler element that requires it.
+ *
+ * <pre>
+ * &lt;handler class="org.wso2.financial.services.accelerator.gateway.dpop.DPoPHandler"&gt;
+ *     &lt;property name="apiDPoPEnabled" value="true"/&gt;
+ * &lt;/handler&gt;
+ * </pre>
+ */
+public class DPoPHandler extends AbstractHandler implements ManagedLifecycle {
+
+    private static final Log log = LogFactory.getLog(DPoPHandler.class);
+
+    // DPoP enforcement is opt-in per API; set value="true" on the handler element to enable.
+    private boolean apiDPoPEnabled = false;
+
+    // Resolved at init() from open-banking.xml
+    private long iatSkewSeconds;
+    private long jtiCacheTtlSeconds;
+    private boolean stripDpopHeader;
+    private boolean httpsRequired;
+
+    // Collaborators built once at init()
+    private DPoPProofValidator proofValidator;
+    private NonceStrategy nonceStrategy;
+    private AccessTokenBinder accessTokenBinder;
+    private Challenge challenge;
+    private DPoPCacheProvider cacheProvider;
+
+    @Override
+    public void init(SynapseEnvironment synapseEnvironment) {
+
+        Map<String, Object> cfg = this.readDPopConfig();
+
+        this.iatSkewSeconds = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.IAT_SKEW_SECONDS),
+                DPoPConstants.Defaults.IAT_SKEW_SECONDS);
+        this.jtiCacheTtlSeconds = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.JTI_CACHE_TTL_SECONDS),
+                DPoPConstants.Defaults.JTI_CACHE_TTL_SECONDS);
+        this.stripDpopHeader = parseBool(cfg.get(DPoPConstants.ConfigKeys.STRIP_DPOP_HEADER),
+                DPoPConstants.Defaults.STRIP_DPOP_HEADER);
+        this.httpsRequired = parseBool(cfg.get(DPoPConstants.ConfigKeys.HTTPS_REQUIRED),
+                DPoPConstants.Defaults.HTTPS_REQUIRED);
+
+        Set<String> algorithms =
+                DPoPUtils.parseAlgorithms((String) cfg.get(DPoPConstants.ConfigKeys.ACCEPTED_ALGORITHMS));
+        String nonceStrategyName = DPoPUtils.parseString(cfg.get(DPoPConstants.ConfigKeys.NONCE_STRATEGY),
+                DPoPConstants.Defaults.NONCE_STRATEGY);
+        int nonceRotateAfterUses = (int) DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.NONCE_ROTATE_AFTER_USES),
+                DPoPConstants.Defaults.NONCE_ROTATE_AFTER_USES);
+        long introspectionTtl = DPoPUtils.parseLong(cfg.get(DPoPConstants.ConfigKeys.INTROSPECTION_CACHE_TTL_SECONDS),
+                DPoPConstants.Defaults.INTROSPECTION_CACHE_TTL_SECONDS);
+
+        this.proofValidator = new DPoPProofValidator(algorithms, iatSkewSeconds);
+        this.nonceStrategy = buildNonceStrategy(nonceStrategyName, nonceRotateAfterUses);
+        this.accessTokenBinder = new AccessTokenBinder(new IntrospectionClient(introspectionTtl));
+        this.challenge = new Challenge(String.join(" ", algorithms));
+
+        this.cacheProvider = buildCacheProvider(cfg);
+
+        log.info("DPoP handler initialized. algorithms=" + algorithms
+                + ", nonceStrategy=" + nonceStrategy.getName()
+                + ", cacheProvider=" + cacheProvider.getClass().getName());
+    }
+
+    @Override
+    public void destroy() {
+        log.info("DPoP handler destroyed.");
+    }
+
+    @Override
+    public boolean handleRequest(MessageContext synCtx) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Handling request in DPoPHandler. apiDPoPEnabled=" + apiDPoPEnabled);
+        }
+        if (!apiDPoPEnabled) {
+            return true;
+        }
+
+        final Map<String, String> headers = DPoPUtils.getTransportHeaders(synCtx);
+        if (headers.isEmpty()) {
+            log.debug("No transport headers found; skipping DPoP validation");
+            return true;
+        }
+
+        final String authHeader = headers.get(AUTH_HEADER);
+        final String dPoPHeader = headers.get(DPOP_HEADER);
+
+        // Declared before try so the catch block can use it without re-parsing the proof JWT.
+        DPoPProofValidator.ParsedProof parsedProof = null;
+
+        try {
+            final boolean isDPoPScheme = authHeader != null
+                    && authHeader.regionMatches(true, 0, DPOP_SCHEME + " ", 0, DPOP_SCHEME_LEN);
+            final boolean isBearerWithDPoP = dPoPHeader != null && authHeader != null
+                    && authHeader.regionMatches(true, 0, BEARER_TAG, 0, BEARER_SCHEME_LEN);
+            String accessToken = DPoPUtils.extractToken(authHeader, isDPoPScheme ? DPOP_SCHEME : BEARER_TAG.trim());
+
+            if (log.isDebugEnabled()) {
+                log.debug("DPoP handler: scheme=" + (isDPoPScheme ? "DPoP" : "Bearer")
+                        + ", hasDPoPProof=" + (dPoPHeader != null));
+            }
+
+            // Parse the proof JWT — kid and JWK thumbprint extracted here are reused
+            // throughout: nonce-cache lookup, full validation, and replay check.
+            if (StringUtils.isNotBlank(dPoPHeader)) {
+                parsedProof = proofValidator.parseDPoPProof(dPoPHeader);
+            }
+
+            // Resolve cnf.jkt — reused for both the early-rejection check below and
+            // the binding verification inside validateDPoP.
+            final String tokenJkt = accessTokenBinder.resolveJkt(accessToken);
+
+            // RFC 9449 §7.1: a DPoP-bound token presented without a proof must be rejected.
+            // For JWT tokens this is detected from claims; for opaque tokens from introspection.
+            if (parsedProof == null && StringUtils.isNotEmpty(tokenJkt)) {
+
+                if (log.isDebugEnabled()) {
+                    log.debug("Rejecting DPoP-bound token presented without a proof: cnf.jkt=" + tokenJkt);
+                }
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                        "DPoP proof required for DPoP-bound access token; retry with the proof");
+            }
+
+            if (!isDPoPScheme && !isBearerWithDPoP) {
+                // No DPoP involvement — downstream APIAuthenticationHandler handles the Bearer case
+                log.debug("No DPoP involvement detected; passing request to downstream handler");
+                return true;
+            }
+
+            // RFC 9449 §4.3: exactly one DPoP header field is required
+            if (DPoPUtils.hasMultipleDPopHeaders(synCtx)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "Multiple DPoP headers found");
+            }
+
+            return validateDPoP(synCtx, headers, accessToken, parsedProof, tokenJkt);
+        } catch (DPoPProofException e) {
+
+            log.error("DPoP validation failed. Caused by,", e);
+            // Use the JWK thumbprint from the parsed DPoP proof as the nonce key.
+            final String proofKeyId = parsedProof != null ? parsedProof.getJwkThumbprint() : null;
+            final String nonce = (e.getErrorCode() == DPoPProofException.ErrorCode.USE_DPOP_NONCE && proofKeyId != null)
+                    ? cacheProvider.issueNonce(proofKeyId)
+                    : null;
+            challenge.send401(synCtx, e.getErrorCode(), e.getMessage(), nonce);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean handleResponse(MessageContext synCtx) {
+
+        final boolean isDPoPBound = parseBool(synCtx.getProperty(DPOP_BOUND_PROPERTY), false);
+        final String rotatedNonce = (String) synCtx.getProperty(DPoPConstants.DPOP_RESPONSE_NONCE_PROPERTY);
+        if (isDPoPBound && rotatedNonce != null) {
+            Map<String, String> headers = DPoPUtils.getTransportHeaders(synCtx);
+            headers.put(DPoPConstants.DPOP_NONCE_HEADER, rotatedNonce);
+            // RFC 9449 §8.2: responses that carry a nonce must not be cached.
+            headers.put(HttpHeaders.CACHE_CONTROL, DPoPConstants.CACHE_CONTROL_NO_STORE);
+            ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                    .setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, headers);
+        }
+        return true;
+    }
+
+    private boolean validateDPoP(MessageContext synCtx, Map<String, String> headers,
+                                 String accessToken, DPoPProofValidator.ParsedProof parsedProof,
+                                 String tokenJkt) throws DPoPProofException {
+
+        if (parsedProof == null) {
+            // Reached when Authorization: DPoP <token> is present but the DPoP header is missing.
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof required; retry with the proof");
+        }
+
+        final String httpMethod = (String) ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                .getProperty(Constants.Configuration.HTTP_METHOD);
+        final String htu = DPoPUtils.normalizeHtu(synCtx, headers);
+
+        if (httpsRequired) {
+            DPoPUtils.checkHttps(htu);
+        }
+
+        // JWK thumbprint is derived from actual key material — preferred over the
+        // client-controlled kid field as the nonce cache key.
+        final String proofJwkThumbprint = parsedProof.getJwkThumbprint();
+
+        if (log.isDebugEnabled()) {
+            log.debug("Validating DPoP proof: method=" + httpMethod + ", htu=" + htu
+                    + ", kid=" + parsedProof.getKid() + ", proofKeyId=" + proofJwkThumbprint);
+        }
+
+        // 1. Nonce check — RFC 9449 §11.3: must reject proofs without nonce whenever one
+        //    has been issued to this client, even between strategy rotation points.
+        boolean strategyRequiresNonce = proofJwkThumbprint != null
+                && nonceStrategy.requiresNonce(proofJwkThumbprint);
+        String activeNonce = proofJwkThumbprint != null
+                ? cacheProvider.getActiveNonce(proofJwkThumbprint) : null;
+
+        String expectedNonce = null;
+        if (strategyRequiresNonce || activeNonce != null) {
+            if (activeNonce == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No active nonce for proofKeyId=" + proofJwkThumbprint + "; challenging client");
+                }
+                throw new DPoPProofException(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                        "DPoP-Nonce required; retry with the issued nonce");
+            }
+            expectedNonce = activeNonce;
+            if (log.isDebugEnabled()) {
+                log.debug("Nonce check required for proofKeyId=" + proofJwkThumbprint);
+            }
+        }
+
+        // 2. Validate proof JWT (signature, header, claims, ath)
+        DPoPProofValidator.ValidationResult result =
+                proofValidator.validate(parsedProof, httpMethod, htu, accessToken, expectedNonce);
+        final String proofJkt = result.getProofJkt();
+
+        // 3. Replay defense — jti comes from the validation result.
+        final String jti = result.getJti();
+        if (log.isDebugEnabled()) {
+            log.debug("Checking jti replay: jti=" + jti);
+        }
+
+        if (jti == null || !cacheProvider.isJtiFirstUse(jti, proofJkt, jtiCacheTtlSeconds)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof jti has already been used (replay detected)");
+        }
+
+        // 4. Token binding — use the resolved tokenJkt
+        accessTokenBinder.verifyBinding(tokenJkt, proofJkt);
+
+        // 5. Rotation — if strategy says rotate, issue fresh nonce and deliver on 200 response (RFC 9449 §8.2).
+        if (proofJwkThumbprint != null && nonceStrategy.shouldRotate(proofJwkThumbprint)) {
+            String rotatedNonce = cacheProvider.issueNonce(proofJwkThumbprint);
+            synCtx.setProperty(DPoPConstants.DPOP_RESPONSE_NONCE_PROPERTY, rotatedNonce);
+            if (log.isDebugEnabled()) {
+                log.debug("Nonce rotated for proofKeyId=" + proofJwkThumbprint);
+            }
+        }
+
+        // 6. Rewrite Authorization: DPoP <token> → Authorization: Bearer <token>
+        //    so the downstream OAuthAuthenticator works unchanged. Remove any case-variant
+        //    of the key first, then write with the canonical case the authenticator expects.
+        DPoPUtils.removeHeader(headers, AUTH_HEADER);
+        headers.put(AUTH_HEADER, BEARER_TAG + accessToken);
+        if (stripDpopHeader) {
+            DPoPUtils.removeHeader(headers, DPOP_HEADER);
+        }
+        ((Axis2MessageContext) synCtx).getAxis2MessageContext()
+                .setProperty(org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS, headers);
+
+        synCtx.setProperty(DPOP_BOUND_PROPERTY, Boolean.TRUE);
+        if (log.isDebugEnabled()) {
+            log.debug("DPoP validation successful for request: " + htu);
+        }
+        return true;
+    }
+
+    private Map<String, Object> readDPopConfig() {
+        if (GatewayDataHolder.getInstance().getOpenBankingConfigurationService() == null) {
+            log.warn("FinancialServicesConfigurationService not available; DPoP handler will use defaults");
+            return Collections.emptyMap();
+        }
+        Map<String, Object> all = GatewayDataHolder.getInstance()
+                .getOpenBankingConfigurationService().getConfigurations();
+        return all == null ? Collections.emptyMap() : all;
+    }
+
+    /**
+     * Resolves the configured {@link DPoPCacheProvider} (default {@link LocalDPoPCacheProvider})
+     * and hands it every {@code Gateway.DPoP.*} key with the prefix stripped, so a custom
+     * impl (e.g. Redis) can read its own backend-specific keys directly from the map
+     * without coupling the SPI to any particular backend.
+     */
+    private DPoPCacheProvider buildCacheProvider(Map<String, Object> cfg) {
+        final String fqn = (String) cfg.get(DPoPConstants.ConfigKeys.CACHE_PROVIDER_CLASS);
+        DPoPCacheProvider provider;
+        if (StringUtils.isBlank(fqn)) {
+            provider = new LocalDPoPCacheProvider();
+        } else {
+            provider = (DPoPCacheProvider) OpenBankingUtils.getClassInstanceFromFQN(fqn);
+        }
+        provider.initialize(collectDPoPProperties(cfg));
+        return provider;
+    }
+
+    private Map<String, Object> collectDPoPProperties(Map<String, Object> cfg) {
+        Map<String, Object> sub = new HashMap<>();
+        final String prefix = DPoPConstants.ConfigKeys.GATEWAY_DPOP_PREFIX;
+        for (Map.Entry<String, Object> e : cfg.entrySet()) {
+            if (e.getKey().startsWith(prefix)) {
+                sub.put(e.getKey().substring(prefix.length()), e.getValue());
+            }
+        }
+        return sub;
+    }
+
+    /**
+     * Maps the configured nonce strategy name to its implementation. Throws
+     * {@link IllegalArgumentException} for unrecognised names to fail fast on misconfiguration
+     * rather than silently falling back to no-nonce enforcement.
+     */
+    private NonceStrategy buildNonceStrategy(String name, int rotateAfterUses) {
+        if (equalsIgnoreCase("always", name)) {
+            return new AlwaysNonceStrategy();
+        }
+        if (equalsIgnoreCase("rotating", name)) {
+            return new RotatingNonceStrategy(rotateAfterUses);
+        }
+        if (equalsIgnoreCase("never", name)) {
+            return new NeverNonceStrategy();
+        }
+        throw new IllegalArgumentException("Unsupported DPoP nonce strategy: " + name);
+    }
+
+    /**
+     * Synapse property setter for the per-API DPoP enforcement toggle.
+     * Set {@code value="true"} on the handler element to enable DPoP enforcement for an API.
+     */
+    public void setApiDPoPEnabled(String apiDPoPEnabled) {
+        this.apiDPoPEnabled = Boolean.parseBoolean(apiDPoPEnabled);
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/AccessTokenBinder.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/AccessTokenBinder.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.binding;
+
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
+import com.wso2.openbanking.accelerator.gateway.dpop.util.DPoPUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Resolves {@code cnf.jkt} from the access token and verifies it against the
+ * computed JWK thumbprint from the DPoP proof.
+ * <ul>
+ *   <li>JWT access tokens: {@code cnf.jkt} is read directly from the JWT claims
+ *       (no signature verification — that is the downstream OAuth authenticator's job).</li>
+ *   <li>Opaque access tokens: {@code cnf.jkt} is obtained via Key Manager introspection;
+ *       results are cached by {@link IntrospectionClient} for the configured TTL so
+ *       repeated calls for the same token within that window avoid extra network calls.</li>
+ * </ul>
+ */
+public class AccessTokenBinder {
+
+    private static final Log log = LogFactory.getLog(AccessTokenBinder.class);
+
+    private final IntrospectionClient introspectionClient;
+
+    public AccessTokenBinder(IntrospectionClient introspectionClient) {
+
+        this.introspectionClient = introspectionClient;
+    }
+
+    /**
+     * Resolves {@code cnf.jkt} from the access token regardless of its format.
+     * <p>
+     * Callers should invoke this once per request and pass the result to
+     * {@link #verifyBinding(String, String)}, so that resolution — whether a
+     * local JWT parse or a remote introspection call.
+     *
+     * @param accessToken raw access token string; {@code null} or blank returns {@code null}
+     * @return the JWK thumbprint, or {@code null} if the token carries no DPoP binding
+     * @throws DPoPProofException if the token is malformed or introspection fails
+     */
+    public String resolveJkt(String accessToken) throws DPoPProofException {
+
+        if (StringUtils.isBlank(accessToken)) {
+            return null;
+        }
+        final boolean isJwt = DPoPUtils.isJwtToken(accessToken);
+        if (log.isDebugEnabled()) {
+            log.debug("Resolving cnf.jkt from " + (isJwt ? "JWT" : "opaque") + " access token");
+        }
+
+        final String jkt = isJwt ? DPoPUtils.extractJktFromJwt(accessToken) : extractJktViaIntrospection(accessToken);
+        if (log.isDebugEnabled()) {
+            log.debug("Resolved cnf.jkt: " + (StringUtils.isNotBlank(jkt) ? jkt : "<none: token is not DPoP-bound>"));
+        }
+        return jkt;
+    }
+
+    /**
+     * Verifies that the pre-resolved JWK thumbprint from the access token matches
+     * the thumbprint computed from the DPoP proof's public key.
+     * <p>
+     * Accepts the already-resolved {@code tokenJkt} (from {@link #resolveJkt}) so
+     * that JWT parsing and introspection are never repeated for the same request.
+     *
+     * @param tokenJkt JWK thumbprint resolved from the access token (may be {@code null})
+     * @param proofJkt JWK thumbprint computed from the validated DPoP proof
+     * @throws DPoPProofException if the token has no DPoP binding or the thumbprints mismatch
+     */
+    public void verifyBinding(String tokenJkt, String proofJkt) throws DPoPProofException {
+        if (StringUtils.isBlank(tokenJkt)) {
+            // Per RFC 9449 §7.1: a token presented under the DPoP scheme must have cnf.jkt.
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                    "Access token presented under DPoP scheme has no cnf.jkt binding");
+        }
+        if (!tokenJkt.equals(proofJkt)) {
+            if (log.isDebugEnabled()) {
+                log.debug("cnf.jkt mismatch: token=" + tokenJkt + ", proof=" + proofJkt);
+            }
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                    "DPoP proof public key thumbprint does not match the access token's cnf.jkt");
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("DPoP token binding verified: cnf.jkt=" + tokenJkt);
+        }
+    }
+
+    /**
+     * Resolves {@code cnf.jkt} for an opaque access token by calling the Key Manager
+     * introspection endpoint. Results are cached by {@link IntrospectionClient} for the
+     * configured TTL to avoid repeated round-trips for the same token.
+     *
+     * @param accessToken raw opaque access token
+     * @return the {@code cnf.jkt} JWK thumbprint, or {@code null} if the token has no DPoP binding
+     * @throws DPoPProofException if the introspection call fails
+     */
+    private String extractJktViaIntrospection(String accessToken) throws DPoPProofException {
+        try {
+            return introspectionClient.getJwkThumbprint(accessToken);
+        } catch (IntrospectionClient.IntrospectionException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                    "Failed to obtain cnf.jkt from token introspection: " + e.getMessage(), e);
+        }
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/IntrospectionClient.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/IntrospectionClient.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.binding;
+
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
+import org.wso2.carbon.apimgt.api.model.KeyManager;
+import org.wso2.carbon.apimgt.impl.dto.KeyManagerDto;
+import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.SHA256_HASH_ALG;
+
+/**
+ * Wraps the APIM Key Manager introspection endpoint to retrieve {@code cnf.jkt}
+ * for opaque tokens. Results are cached keyed by a SHA-256 hash of the raw token
+ * to avoid repeated round-trips for the same token within its validity window.
+ */
+public class IntrospectionClient {
+
+    private static final Log log = LogFactory.getLog(IntrospectionClient.class);
+
+    private final long cacheTtlMs;
+    private final ConcurrentHashMap<String, CachedEntry> introspectionCache = new ConcurrentHashMap<>();
+
+    public IntrospectionClient(long cacheTtlSeconds) {
+        this.cacheTtlMs = cacheTtlSeconds * 1000L;
+    }
+
+    /**
+     * Returns the {@code cnf.jkt} from token introspection, or {@code null} if the
+     * token has no DPoP binding.
+     *
+     * @param accessToken raw opaque access token
+     * @throws IntrospectionException if the introspection call fails
+     */
+    public String getJwkThumbprint(String accessToken) throws IntrospectionException {
+        String cacheKey = hashToken(accessToken);
+        CachedEntry cached = introspectionCache.get(cacheKey);
+        if (cached != null && !cached.isExpired()) {
+            return cached.jkt;
+        }
+        if (cached != null) {
+            // Remove the stale entry so putIfAbsent below can store the fresh result.
+            // Using the value-matched overload is safe under concurrent updates: if another
+            // thread already replaced this entry, remove() is a no-op.
+            introspectionCache.remove(cacheKey, cached);
+        }
+        final String jkt = introspect(accessToken);
+        if (StringUtils.isNotBlank(jkt)) {
+            // putIfAbsent: if two threads race here, the first writer wins and the second
+            // result is silently discarded — both return the same jkt (introspection is deterministic).
+            introspectionCache.putIfAbsent(cacheKey,
+                    new CachedEntry(jkt, System.currentTimeMillis() + cacheTtlMs));
+        }
+        return jkt;
+    }
+
+    /**
+     * Iterates over all Key Managers configured for the current tenant and returns
+     * the first {@code cnf.jkt} found for the given token.
+     *
+     * @param accessToken raw opaque access token
+     * @return the {@code cnf.jkt} JWK thumbprint, or {@code null} if the token has no DPoP binding
+     * @throws IntrospectionException if all Key Managers fail or none are configured
+     */
+    private String introspect(String accessToken) throws IntrospectionException {
+
+        final String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain(true);
+        Map<String, KeyManagerDto> keyManagerDtoMap = KeyManagerHolder.getTenantKeyManagers(tenantDomain);
+        if (keyManagerDtoMap == null || keyManagerDtoMap.isEmpty()) {
+            throw new IntrospectionException("No key manager configured for tenant: " + tenantDomain);
+        }
+        for (Map.Entry<String, KeyManagerDto> entry : keyManagerDtoMap.entrySet()) {
+            KeyManager keyManager = entry.getValue().getKeyManager();
+            if (keyManager == null) {
+                continue;
+            }
+            try {
+                AccessTokenInfo tokenInfo = keyManager.getTokenMetaData(accessToken);
+                if (tokenInfo == null || !tokenInfo.isTokenValid()) {
+                    continue;
+                }
+                Object cnf = tokenInfo.getParameter(DPoPConstants.Claims.CNF_CLAIM);
+                if (cnf instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Object jkt = ((Map<String, Object>) cnf).get(DPoPConstants.Claims.JKT_CLAIM);
+                    return jkt != null ? jkt.toString() : null;
+                }
+                return null;
+            } catch (APIManagementException e) {
+                log.error("Key manager " + entry.getKey()
+                        + " failed to introspect token, trying next: " + e.getMessage(), e);
+            }
+        }
+        throw new IntrospectionException("Token introspection failed for all configured key managers");
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest md = MessageDigest.getInstance(SHA256_HASH_ALG);
+            byte[] hash = md.digest(token.getBytes(StandardCharsets.US_ASCII));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            log.debug("SHA-256 algorithm not available for token hashing, falling back to hashCode", e);
+            return String.valueOf(token.hashCode());
+        }
+    }
+
+    private static final class CachedEntry {
+
+        final String jkt;
+        final long expiresAt;
+
+        CachedEntry(String jkt, long expiresAt) {
+            this.jkt = jkt;
+            this.expiresAt = expiresAt;
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() > expiresAt;
+        }
+    }
+
+    /**
+     * Thrown when the upstream introspection endpoint cannot resolve a token.
+     */
+    public static class IntrospectionException extends Exception {
+
+        private static final long serialVersionUID = 87452349823745L;
+
+        public IntrospectionException(String message) {
+            super(message);
+        }
+
+        public IntrospectionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/DPoPCacheKey.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/DPoPCacheKey.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.cache;
+
+import com.wso2.openbanking.accelerator.common.caching.OpenBankingBaseCacheKey;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Cache key for DPoP JTI replay-defense and nonce caches.
+ */
+public class DPoPCacheKey extends OpenBankingBaseCacheKey implements Serializable {
+
+    private static final long serialVersionUID = 6823941170341530021L;
+    private final String dPoPCacheKey;
+
+    public DPoPCacheKey(String dPoPCacheKey) {
+
+        this.dPoPCacheKey = dPoPCacheKey;
+    }
+
+    public static DPoPCacheKey of(String dPoPCacheKey) {
+
+        return new DPoPCacheKey(dPoPCacheKey);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DPoPCacheKey that = (DPoPCacheKey) o;
+        return Objects.equals(dPoPCacheKey, that.dPoPCacheKey);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(dPoPCacheKey);
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/DPoPCacheProvider.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/DPoPCacheProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.cache;
+
+import java.util.Map;
+
+/**
+ * SPI for the two pieces of state the DPoP handler maintains: the JTI replay-defense
+ * set (per RFC 9449 §11.1) and the per-client nonce store (per §8).
+ * <p>
+ * The default implementation {@link LocalDPoPCacheProvider} uses the gateway's
+ * node-local Carbon javax.cache and is sufficient for single-node deployments.
+ * Distributed deployments must provide their own implementation (e.g. Redis-backed)
+ * via {@code Gateway.DPoP.CacheProviderClass} in {@code open-banking.xml},
+ * because a node-local seen-set is racy across cluster members — a replayed proof
+ * routed to a different node would not be detected.
+ * <p>
+ * Implementations must be safe for concurrent use by multiple gateway worker threads.
+ * {@link #isJtiFirstUse} must be atomic; a partial overlap between the read and write
+ * is not acceptable.
+ */
+public interface DPoPCacheProvider {
+
+    /**
+     * Called once at handler init. The map contains every {@code Gateway.DPoP.*} key
+     * declared in {@code open-banking.xml}, stripped of the {@code Gateway.DPoP.}
+     * prefix, so an implementation can read its own backend-specific keys (e.g.
+     * {@code Cache.Redis.Host}) without coupling the SPI to any particular backend.
+     */
+    void initialize(Map<String, Object> properties);
+
+    /**
+     * Atomically checks whether the {@code (jti, jkt)} pair has been seen before and
+     * records it if not. Returns {@code true} if this is the first occurrence of the pair
+     * (the proof is fresh and has been recorded), {@code false} if it was already present
+     * (the proof is a replay and must be rejected).
+     *
+     * @param jti        the {@code jti} claim from the DPoP proof
+     * @param jkt        the SHA-256 JWK thumbprint of the proof's public key (sender scope)
+     * @param ttlSeconds how long the entry must remain in the cache
+     */
+    boolean isJtiFirstUse(String jti, String jkt, long ttlSeconds);
+
+    /**
+     * Generates a fresh nonce, stores it against {@code proofKeyId} (replacing any prior
+     * value), and returns it. The TTL is determined by the implementation's configuration
+     * set at {@link #initialize} time.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key
+     */
+    String issueNonce(String proofKeyId);
+
+    /**
+     * Returns the currently active nonce for {@code proofKeyId}, or {@code null} if none.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key
+     */
+    String getActiveNonce(String proofKeyId);
+
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/DPoPJtiCache.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/DPoPJtiCache.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.cache;
+
+import com.wso2.openbanking.accelerator.common.caching.OpenBankingBaseCache;
+
+/**
+ * Cache for DPoP proof JTI replay defense (RFC 9449 §11.1).
+ * Records each seen {@code (jti, jkt)} pair and rejects duplicates.
+ */
+public class DPoPJtiCache extends OpenBankingBaseCache<DPoPCacheKey, String> {
+
+    private static final String CACHE_NAME = "OPEN_BANKING_DPOP_JTI_CACHE";
+
+    private final Integer accessExpiryMinutes;
+    private final Integer modifiedExpiryMinutes;
+
+    public DPoPJtiCache(long ttlSeconds) {
+
+        super(CACHE_NAME);
+        int minutes = Math.max(1, (int) Math.ceil((double) ttlSeconds / 60));
+        this.accessExpiryMinutes = minutes;
+        this.modifiedExpiryMinutes = minutes;
+    }
+
+    /**
+     * Atomically checks whether the {@code (jti, jkt)} pair is new and records it if so.
+     *
+     * @param jti the {@code jti} claim from the DPoP proof.
+     * @param jkt the SHA-256 JWK thumbprint of the proof's public key.
+     * @return true if this is the first use of the pair, false if it is a replay.
+     */
+    public boolean isJtiFirstUse(String jti, String jkt) {
+
+        return addToCacheIfAbsent(DPoPCacheKey.of(jti + ":" + jkt), Boolean.TRUE.toString());
+    }
+
+    @Override
+    public int getCacheAccessExpiryMinutes() {
+
+        return accessExpiryMinutes;
+    }
+
+    @Override
+    public int getCacheModifiedExpiryMinutes() {
+
+        return modifiedExpiryMinutes;
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/DPoPNonceCache.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/DPoPNonceCache.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.cache;
+
+import com.wso2.openbanking.accelerator.common.caching.OpenBankingBaseCache;
+
+/**
+ * Cache for DPoP nonce storage (RFC 9449 §8).
+ * Maintains the active nonce per client; nonces are reusable until the server rotates them.
+ */
+public class DPoPNonceCache extends OpenBankingBaseCache<DPoPCacheKey, String> {
+
+    private static final String CACHE_NAME = "OPEN_BANKING_DPOP_NONCE_CACHE";
+
+    private final Integer accessExpiryMinutes;
+    private final Integer modifiedExpiryMinutes;
+
+    public DPoPNonceCache(long ttlSeconds) {
+
+        super(CACHE_NAME);
+        int minutes = Math.max(1, (int) Math.ceil((double) ttlSeconds / 60));
+        this.accessExpiryMinutes = minutes;
+        this.modifiedExpiryMinutes = minutes;
+    }
+
+    /**
+     * Stores the nonce for the given key, replacing any previously active nonce.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key.
+     * @param nonce      the nonce value to store.
+     */
+    public void storeNonce(String proofKeyId, String nonce) {
+
+        addToCache(DPoPCacheKey.of(proofKeyId), nonce);
+    }
+
+    /**
+     * Returns the currently active nonce for the given key, or {@code null} if none exists.
+     *
+     * @param proofKeyId the nonce cache key, typically the JWK thumbprint of the proof's public key.
+     * @return the active nonce, or {@code null}.
+     */
+    public String getActiveNonce(String proofKeyId) {
+
+        return getFromCache(DPoPCacheKey.of(proofKeyId));
+    }
+
+    @Override
+    public int getCacheAccessExpiryMinutes() {
+
+        return accessExpiryMinutes;
+    }
+
+    @Override
+    public int getCacheModifiedExpiryMinutes() {
+
+        return modifiedExpiryMinutes;
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/LocalDPoPCacheProvider.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/LocalDPoPCacheProvider.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.cache;
+
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+
+import static com.wso2.openbanking.accelerator.gateway.dpop.util.DPoPUtils.parseLong;
+
+/**
+ * Default {@link DPoPCacheProvider} backed by the gateway's node-local
+ * {@code FinancialServicesBaseCache} infrastructure. Suitable for single-node deployments.
+ * Distributed gateway deployments require a cluster-aware implementation since the JTI
+ * seen-set and nonce store are not replicated across nodes — a replayed proof or a reused
+ * nonce routed to a different node would not be detected.
+ */
+public class LocalDPoPCacheProvider implements DPoPCacheProvider {
+
+    private static final Log log = LogFactory.getLog(LocalDPoPCacheProvider.class);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private DPoPJtiCache jtiCache;
+    private DPoPNonceCache nonceCache;
+
+    @Override
+    public void initialize(Map<String, Object> properties) {
+
+        long jtiTtl = parseLong(properties.get("JtiCacheTtlSeconds"),
+                DPoPConstants.Defaults.JTI_CACHE_TTL_SECONDS);
+        long nonceTtl = parseLong(properties.get("NonceTtlSeconds"),
+                DPoPConstants.Defaults.NONCE_TTL_SECONDS);
+
+        this.jtiCache = new DPoPJtiCache(jtiTtl);
+        this.nonceCache = new DPoPNonceCache(nonceTtl);
+
+        if (log.isDebugEnabled()) {
+            log.debug("LocalDPoPCacheProvider initialized. jtiTtlSeconds=" + jtiTtl
+                    + ", nonceTtlSeconds=" + nonceTtl);
+        }
+    }
+
+    /**
+     * {@code ttlSeconds} is consumed at initialization; this parameter is ignored per call.
+     */
+    @Override
+    public boolean isJtiFirstUse(String jti, String jkt, long ttlSeconds) {
+
+        return jtiCache.isJtiFirstUse(jti, jkt);
+    }
+
+    /**
+     * Generates a cryptographically random nonce, stores it against {@code proofKeyId}
+     * replacing any prior value, and returns it to be sent in the {@code DPoP-Nonce}
+     * response header.
+     */
+    @Override
+    public String issueNonce(String proofKeyId) {
+
+        String nonce = generateNonce();
+        nonceCache.storeNonce(proofKeyId, nonce);
+        return nonce;
+    }
+
+    /**
+     * Returns the currently active nonce for {@code proofKeyId}, or {@code null} if none
+     * has been issued yet.
+     */
+    @Override
+    public String getActiveNonce(String proofKeyId) {
+
+        return nonceCache.getActiveNonce(proofKeyId);
+    }
+
+    private String generateNonce() {
+
+        byte[] bytes = new byte[16];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/AlwaysNonceStrategy.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/AlwaysNonceStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.nonce;
+
+/**
+ * Always requires a DPoP-Nonce on every request.
+ */
+public class AlwaysNonceStrategy implements NonceStrategy {
+
+    @Override
+    public boolean requiresNonce(String clientIdentity) {
+
+        return true;
+    }
+
+    @Override
+    public boolean shouldRotate(String clientIdentity) {
+
+        // Nonce is reused until the TTL expires; rotation is driven by expiry, not by use-count.
+        return false;
+    }
+
+    @Override
+    public String getName() {
+
+        return "always";
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NeverNonceStrategy.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NeverNonceStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.nonce;
+
+/**
+ * Never requires a DPoP-Nonce. Default strategy — lowest client friction.
+ */
+public class NeverNonceStrategy implements NonceStrategy {
+
+    @Override
+    public boolean requiresNonce(String clientIdentity) {
+
+        return false;
+    }
+
+    @Override
+    public boolean shouldRotate(String clientIdentity) {
+
+        return false;
+    }
+
+    @Override
+    public String getName() {
+
+        return "never";
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NonceStrategy.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NonceStrategy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.nonce;
+
+/**
+ * Strategy interface deciding whether a DPoP-Nonce is required for a given client
+ * and when to rotate it. Client identity is normally the JWK thumbprint of the proof's public key.
+ */
+public interface NonceStrategy {
+
+    /**
+     * Pure policy check — returns {@code true} if this strategy requires nonces at all.
+     * Must be side-effect-free; the handler calls it on every request.
+     */
+    boolean requiresNonce(String clientIdentity);
+
+    /**
+     * Called once after each successful proof validation. Returns {@code true} when the
+     * strategy decides the current nonce should be rotated (i.e. a fresh nonce should be
+     * issued and delivered in the {@code 200} response per RFC 9449 §8.2).
+     */
+    boolean shouldRotate(String clientIdentity);
+
+    /**
+     * Returns the strategy name used in {@code open-banking.xml}.
+     */
+    String getName();
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NonceStrategyType.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NonceStrategyType.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.nonce;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * Registry of built-in {@link NonceStrategy} implementations. Each constant owns its
+ * factory so that adding a new strategy requires touching only this file.
+ */
+public enum NonceStrategyType {
+
+    NEVER("never", (uses, cap) -> new NeverNonceStrategy()),
+    ALWAYS("always", (uses, cap) -> new AlwaysNonceStrategy()),
+    ROTATING("rotating", RotatingNonceStrategy::new);
+
+    private final String configKey;
+    private final BiFunction<Integer, Integer, NonceStrategy> factory;
+
+    NonceStrategyType(String configKey, BiFunction<Integer, Integer, NonceStrategy> factory) {
+
+        this.configKey = configKey;
+        this.factory = factory;
+    }
+
+    /**
+     * Instantiates the strategy with the supplied rotation parameters.
+     * Strategies that do not use these parameters simply ignore them.
+     */
+    public NonceStrategy create(int rotateAfterUses, int maxTrackedClients) {
+
+        return factory.apply(rotateAfterUses, maxTrackedClients);
+    }
+
+    /**
+     * Looks up a {@link NonceStrategyType} by its config-file key (case-insensitive).
+     * Returns {@link Optional#empty()} for unrecognised names — the caller decides
+     * whether to warn and fall back or to fail fast.
+     */
+    public static Optional<NonceStrategyType> fromName(String name) {
+
+        return Arrays.stream(values())
+                .filter(t -> t.configKey.equalsIgnoreCase(name))
+                .findFirst();
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/RotatingNonceStrategy.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/RotatingNonceStrategy.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.nonce;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Rotates the nonce every {@code rotateAfterUses} successful proof validations per client.
+ * The nonce is reused between rotations; a fresh nonce is delivered proactively in the
+ * {@code 200} response (RFC 9449 §8.2) so the client never pays an extra round-trip.
+ */
+public class RotatingNonceStrategy implements NonceStrategy {
+
+    private static final int MAX_TRACKED_CLIENTS = 10_000;
+
+    private final int rotateAfterUses;
+    // Access-ordered LRU map — evicts the least-recently-seen client identity once the
+    // cap is reached, preventing unbounded growth for long-running gateway instances.
+    private final Map<String, AtomicLong> useCounts = Collections.synchronizedMap(
+            new LinkedHashMap<String, AtomicLong>(MAX_TRACKED_CLIENTS, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, AtomicLong> eldest) {
+                    return size() > MAX_TRACKED_CLIENTS;
+                }
+            });
+
+    public RotatingNonceStrategy(int rotateAfterUses) {
+
+        this.rotateAfterUses = Math.max(1, rotateAfterUses);
+    }
+
+    /**
+     * Pure policy check — always returns {@code true} because once a nonce is issued to a
+     * client it must be required on every subsequent request (RFC 9449 §11.3). First-issue
+     * is handled by the {@code activeNonce == null} path in the handler, not here.
+     */
+    @Override
+    public boolean requiresNonce(String clientIdentity) {
+
+        return true;
+    }
+
+    /**
+     * Increments the per-client use counter and returns {@code true} every
+     * {@code rotateAfterUses}-th call, triggering proactive nonce rotation.
+     */
+    @Override
+    public boolean shouldRotate(String clientIdentity) {
+
+        AtomicLong counter;
+        synchronized (useCounts) {
+            counter = useCounts.computeIfAbsent(clientIdentity, k -> new AtomicLong(0));
+        }
+        long count = counter.incrementAndGet();
+        return count % rotateAfterUses == 0;
+    }
+
+    @Override
+    public String getName() {
+
+        return "rotating";
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/RotatingNonceStrategy.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/RotatingNonceStrategy.java
@@ -30,22 +30,22 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RotatingNonceStrategy implements NonceStrategy {
 
-    private static final int MAX_TRACKED_CLIENTS = 10_000;
-
     private final int rotateAfterUses;
-    // Access-ordered LRU map — evicts the least-recently-seen client identity once the
-    // cap is reached, preventing unbounded growth for long-running gateway instances.
-    private final Map<String, AtomicLong> useCounts = Collections.synchronizedMap(
-            new LinkedHashMap<String, AtomicLong>(MAX_TRACKED_CLIENTS, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<String, AtomicLong> eldest) {
-                    return size() > MAX_TRACKED_CLIENTS;
-                }
-            });
+    private final int maxTrackedClients;
+    // Access-ordered LRU map — evicts the least-recently-seen client identity once the cap is reached.
+    private final Map<String, AtomicLong> useCounts;
 
-    public RotatingNonceStrategy(int rotateAfterUses) {
+    public RotatingNonceStrategy(int rotateAfterUses, int maxTrackedClients) {
 
         this.rotateAfterUses = Math.max(1, rotateAfterUses);
+        this.maxTrackedClients = Math.max(1, maxTrackedClients);
+        this.useCounts = Collections.synchronizedMap(
+                new LinkedHashMap<String, AtomicLong>(this.maxTrackedClients, 0.75f, true) {
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<String, AtomicLong> eldest) {
+                        return size() > RotatingNonceStrategy.this.maxTrackedClients;
+                    }
+                });
     }
 
     /**

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/proof/DPoPProofException.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/proof/DPoPProofException.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.proof;
+
+/**
+ * Signals a DPoP proof validation failure per RFC 9449. Carries the RFC-defined
+ * error code used in the {@code WWW-Authenticate} challenge sent back to clients.
+ */
+public class DPoPProofException extends Exception {
+
+    private static final long serialVersionUID = 8473629184756L;
+
+    /**
+     * RFC 9449 §7.1 error codes returned in the challenge.
+     */
+    public enum ErrorCode {
+
+        /**
+         * The DPoP proof JWT itself failed validation (§4.3).
+         */
+        INVALID_DPOP_PROOF("invalid_dpop_proof"),
+
+        /**
+         * The access token is invalid or the DPoP binding check failed.
+         */
+        INVALID_TOKEN("invalid_token"),
+
+        /**
+         * The server requires a DPoP-Nonce and none was supplied or it was stale.
+         */
+        USE_DPOP_NONCE("use_dpop_nonce");
+
+        private final String value;
+
+        ErrorCode(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    private final ErrorCode errorCode;
+
+    public DPoPProofException(ErrorCode errorCode, String message) {
+
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public DPoPProofException(ErrorCode errorCode, String message, Throwable cause) {
+
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+
+        return errorCode;
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/proof/DPoPProofValidator.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/proof/DPoPProofValidator.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.proof;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.crypto.Ed25519Verifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.ThumbprintUtils;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Set;
+
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_JWT_TYPE;
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.SHA256_HASH_ALG;
+import static org.apache.commons.lang.StringUtils.equalsIgnoreCase;
+
+
+/**
+ * Pure JOSE proof validation per RFC 9449 §4.2 and §4.3. Has no Synapse or APIM
+ * runtime dependencies; safe to unit-test in isolation.
+ * <p>
+ * Usage: construct once with the desired algorithm allow-list and clock skew,
+ * then call {@link #validate} once per request.
+ */
+public class DPoPProofValidator {
+
+    private static final Log log = LogFactory.getLog(DPoPProofValidator.class);
+
+    private final Set<String> acceptedAlgorithms;
+    private final long iatSkewMillis;
+
+    public DPoPProofValidator(Set<String> acceptedAlgorithms, long iatSkewSeconds) {
+
+        this.acceptedAlgorithms = acceptedAlgorithms;
+        this.iatSkewMillis = iatSkewSeconds * 1000L;
+    }
+
+    /**
+     * Lightweight result of the initial proof JWT parse. Holds the data needed before
+     * full validation — the JWK thumbprint for nonce-cache lookup and the {@code kid}
+     * for logging. Pass to {@link #validate} to complete the cryptographic checks.
+     */
+    public static final class ParsedProof {
+
+        private final SignedJWT signedJWT;
+        private final String kid;
+        private final String jwkThumbprint;
+
+        private ParsedProof(SignedJWT signedJWT, String kid, String jwkThumbprint) {
+
+            this.signedJWT = signedJWT;
+            this.kid = kid;
+            this.jwkThumbprint = jwkThumbprint;
+        }
+
+        /**
+         * The {@code kid} from the embedded JWK in the proof header, or {@code null} if absent.
+         */
+        public String getKid() {
+
+            return kid;
+        }
+
+        /**
+         * SHA-256 JWK thumbprint computed from the proof header's {@code jwk} claim before full
+         * validation. Use this as the nonce cache key — it is derived from the actual public key
+         * material and is independent of the client-controlled {@code kid} value. Returns
+         * {@code null} if the {@code jwk} claim is absent (header validation will reject the proof
+         * when {@link DPoPProofValidator#validate} is called).
+         */
+        public String getJwkThumbprint() {
+
+            return jwkThumbprint;
+        }
+    }
+
+    /**
+     * The verified outputs of a successful DPoP proof validation.
+     */
+    public static final class ValidationResult {
+
+        private final String proofJkt;
+        private final String jti;
+
+        private ValidationResult(String proofJkt, String jti) {
+
+            this.proofJkt = proofJkt;
+            this.jti = jti;
+        }
+
+        /**
+         * Base64url SHA-256 JWK thumbprint of the proof's public key (from the validated header).
+         */
+        public String getProofJkt() {
+
+            return proofJkt;
+        }
+
+        /**
+         * The {@code jti} (JWT ID) from the proof claims — use for replay detection.
+         */
+        public String getJti() {
+
+            return jti;
+        }
+    }
+
+    /**
+     * Parses the raw DPoP proof string and extracts the fields needed before full validation:
+     * the JWK thumbprint (preferred nonce cache key, derived from key material) and {@code kid}.
+     * Pass the returned {@link ParsedProof} to {@link #validate} to complete
+     * the cryptographic checks.
+     *
+     * @param proofJwt raw value of the {@code DPoP} HTTP header
+     * @return parsed proof ready for full validation
+     * @throws DPoPProofException if the JWT is blank or not parseable
+     */
+    public ParsedProof parseDPoPProof(String proofJwt) throws DPoPProofException {
+
+        if (StringUtils.isBlank(proofJwt)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof header is missing");
+        }
+        SignedJWT signedJWT;
+        try {
+            signedJWT = SignedJWT.parse(proofJwt);
+        } catch (ParseException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof JWT is not parseable: " + e.getMessage(), e);
+        }
+        JWK jwk = signedJWT.getHeader().getJWK();
+        String kid = null;
+        String jwkThumbprint = null;
+        if (jwk != null) {
+            kid = jwk.getKeyID();
+            try {
+                jwkThumbprint = ThumbprintUtils.compute(SHA256_HASH_ALG, jwk).toString();
+            } catch (JOSEException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to compute preliminary JWK thumbprint in parseDPoPProof; "
+                            + "header validation will reject this proof shortly", e);
+                }
+            }
+        }
+        return new ParsedProof(signedJWT, kid, jwkThumbprint);
+    }
+
+    /**
+     * Validates a pre-parsed DPoP proof JWT against RFC 9449 §4.3 rules.
+     * Accepts the result of {@link #parseDPoPProof} so the JWT string is parsed exactly once.
+     *
+     * @param parsedProof   result of {@link #parseDPoPProof}
+     * @param requestHtm    HTTP method of the request
+     * @param requestHtu    normalized HTTP URI of the request (no query/fragment)
+     * @param accessToken   raw access token (for {@code ath} verification), or {@code null}
+     * @param expectedNonce server nonce to match, or {@code null} if nonces are not required
+     * @return validation result containing the JWK thumbprint and {@code jti}
+     * @throws DPoPProofException if any validation step fails
+     */
+    public ValidationResult validate(ParsedProof parsedProof, String requestHtm, String requestHtu,
+                                     String accessToken, String expectedNonce) throws DPoPProofException {
+
+        JWSHeader header = parsedProof.signedJWT.getHeader();
+        JWK jwk = validateHeader(header);
+
+        verifySignature(parsedProof.signedJWT, jwk);
+
+        JWTClaimsSet claims = parseClaims(parsedProof.signedJWT);
+        validateClaims(claims, requestHtm, requestHtu, accessToken, expectedNonce);
+
+        return new ValidationResult(computeJwkThumbprint(jwk), claims.getJWTID());
+    }
+
+    /**
+     * Validates the DPoP proof JOSE header per RFC 9449 §4.3 rules 4–7:
+     * {@code typ} must be {@code dpop+jwt}, {@code alg} must be asymmetric and in the
+     * accepted list, {@code jwk} must be present and must not contain private key material.
+     *
+     * @param header the JWS header of the parsed proof JWT
+     * @return the public JWK embedded in the header
+     * @throws DPoPProofException if any header constraint is violated
+     */
+    private JWK validateHeader(JWSHeader header) throws DPoPProofException {
+        // RFC 9449 §4.3 rule 4: typ must be "dpop+jwt"
+        if (header.getType() == null || !equalsIgnoreCase(DPOP_JWT_TYPE, (header.getType().getType()))) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof typ must be \"dpop+jwt\", got: " + header.getType());
+        }
+
+        // RFC 9449 §4.3 rule 5: alg must be asymmetric and in the allow-list
+        JWSAlgorithm alg = header.getAlgorithm();
+        if (alg == null || JWSAlgorithm.Family.HMAC_SHA.contains(alg) || JWSAlgorithm.NONE.equals(alg)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof alg must be an asymmetric algorithm, got: " + alg);
+        }
+        if (!acceptedAlgorithms.contains(alg.getName())) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof alg \"" + alg.getName() + "\" is not in the accepted algorithm list");
+        }
+
+        // RFC 9449 §4.3 rule 6: jwk must be present
+        JWK jwk = header.getJWK();
+        if (jwk == null) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof header must contain a jwk claim");
+        }
+        // RFC 9449 §4.3 rule 7: jwk must not contain private key material
+        if (jwk.isPrivate()) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof jwk must not contain private key material");
+        }
+        return jwk;
+    }
+
+    /**
+     * Verifies the DPoP proof signature against the public key embedded in its header.
+     *
+     * @param signedJWT the parsed proof JWT
+     * @param jwk       the public key extracted from the proof header
+     * @throws DPoPProofException if signature verification fails or the JWK type is unsupported
+     */
+    private void verifySignature(SignedJWT signedJWT, JWK jwk) throws DPoPProofException {
+        try {
+            JWSVerifier verifier = buildVerifier(jwk);
+            if (!signedJWT.verify(verifier)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "DPoP proof signature verification failed");
+            }
+        } catch (JOSEException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof signature verification error: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Constructs a {@link JWSVerifier} for the given JWK key type (RSA, EC, or OKP/Ed25519).
+     *
+     * @param jwk the public key from the proof header
+     * @return a verifier suitable for the key type
+     * @throws JOSEException      if the key material cannot be parsed
+     * @throws DPoPProofException if the key type or OKP curve is unsupported
+     */
+    private JWSVerifier buildVerifier(JWK jwk) throws JOSEException, DPoPProofException {
+        KeyType keyType = jwk.getKeyType();
+        if (KeyType.RSA.equals(keyType)) {
+            return new RSASSAVerifier(((RSAKey) jwk).toRSAPublicKey());
+        } else if (KeyType.EC.equals(keyType)) {
+            return new ECDSAVerifier(((ECKey) jwk).toECPublicKey());
+        } else if (KeyType.OKP.equals(keyType)) {
+            OctetKeyPair okp = (OctetKeyPair) jwk;
+            if (!Curve.Ed25519.equals(okp.getCurve())) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "Unsupported OKP curve: " + okp.getCurve());
+            }
+            return new Ed25519Verifier(okp.toPublicJWK());
+        }
+        throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                "Unsupported JWK key type: " + keyType);
+    }
+
+    /**
+     * Extracts the JWT claims set from the signed JWT.
+     *
+     * @param signedJWT the parsed and signature-verified proof JWT
+     * @return the claims set
+     * @throws DPoPProofException if the claims payload cannot be parsed
+     */
+    private JWTClaimsSet parseClaims(SignedJWT signedJWT) throws DPoPProofException {
+
+        try {
+            return signedJWT.getJWTClaimsSet();
+        } catch (ParseException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "Failed to parse DPoP proof claims: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Validates proof claims per RFC 9449 §4.3 rules 8–12:
+     * {@code htm} must match the request method, {@code htu} must match the normalized
+     * request URI, {@code iat} must be within the skew window, {@code ath} must equal
+     * the access token hash when a token is present, and {@code nonce} must match the
+     * server-issued nonce when one is required.
+     *
+     * @param claims        the claims set from the proof JWT
+     * @param requestHtm    HTTP method of the current request
+     * @param requestHtu    normalized request URI (no query or fragment)
+     * @param accessToken   raw access token for {@code ath} verification, or {@code null}
+     * @param expectedNonce server-issued nonce to match, or {@code null} if not required
+     * @throws DPoPProofException if any claim constraint is violated
+     */
+    private void validateClaims(JWTClaimsSet claims, String requestHtm, String requestHtu,
+                                String accessToken, String expectedNonce) throws DPoPProofException {
+
+        if (StringUtils.isBlank(claims.getJWTID())) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof must contain a jti claim");
+        }
+
+        // RFC 9449 §4.3 rule 8: htm must match request method
+        String htm = (String) claims.getClaim(DPoPConstants.Claims.HTM_CLAIM);
+        if (!equalsIgnoreCase(requestHtm, htm)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof htm \"" + htm + "\" does not match request method \"" + requestHtm + "\"");
+        }
+
+        // RFC 9449 §4.3 rule 9: htu must match normalized request URI
+        String htu = removeQueryAndFragment((String) claims.getClaim(DPoPConstants.Claims.HTU_CLAIM));
+        if (!normalizedUriEquals(requestHtu, htu)) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof htu \"" + htu + "\" does not match request URI \"" + requestHtu + "\"");
+        }
+
+        // RFC 9449 §4.3 rule 11: iat must be within the acceptance window
+        Date iat = claims.getIssueTime();
+        if (iat == null) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof must contain an iat claim");
+        }
+        long now = System.currentTimeMillis();
+        if (Math.abs(now - iat.getTime()) > iatSkewMillis) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP proof iat is outside the acceptance window");
+        }
+
+        if (accessToken != null) {
+            // RFC 9449 §4.3 rule 12: ath must equal base64url(SHA-256(ASCII(accessToken)))
+            String ath = (String) claims.getClaim(DPoPConstants.Claims.ATH_CLAIM);
+            if (StringUtils.isBlank(ath)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "DPoP proof must contain an ath claim when an access token is presented");
+            }
+            String expectedAth = computeAth(accessToken);
+            if (!expectedAth.equals(ath)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                        "DPoP proof ath does not match the access token hash");
+            }
+        }
+
+        // RFC 9449 §4.3 rule 10: nonce claim must match the server-issued nonce when required
+        if (expectedNonce != null) {
+            String nonce = (String) claims.getClaim(DPoPConstants.Claims.NONCE_CLAIM);
+            if (!expectedNonce.equals(nonce)) {
+                throw new DPoPProofException(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                        "DPoP proof nonce is missing or does not match the server-issued nonce");
+            }
+        }
+    }
+
+    /**
+     * Computes the base64url-encoded SHA-256 JWK thumbprint per RFC 7638.
+     */
+    private String computeJwkThumbprint(JWK jwk) throws DPoPProofException {
+
+        try {
+            Base64URL thumbprint = ThumbprintUtils.compute(SHA256_HASH_ALG, jwk);
+            return thumbprint.toString();
+        } catch (JOSEException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "Failed to compute JWK thumbprint: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Computes the {@code ath} claim value as {@code base64url(SHA-256(ASCII(accessToken)))}
+     * per RFC 9449 §4.2.
+     *
+     * @param accessToken raw access token string
+     * @return base64url-encoded SHA-256 hash of the ASCII-encoded token
+     * @throws DPoPProofException if the SHA-256 algorithm is unavailable on this JVM
+     */
+    private String computeAth(String accessToken) throws DPoPProofException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(SHA256_HASH_ALG);
+            byte[] hash = digest.digest(accessToken.getBytes(StandardCharsets.US_ASCII));
+            return Base64URL.encode(hash).toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "SHA-256 not available", e);
+        }
+    }
+
+    /**
+     * Returns {@code true} if {@code a} and {@code b} are equal after stripping trailing
+     * slashes and ignoring case, following the URI normalization requirements of RFC 9449 §4.3.
+     *
+     * @param a first URI string, may be {@code null}
+     * @param b second URI string, may be {@code null}
+     * @return {@code true} if the normalized URIs are equal; {@code false} if either is {@code null}
+     */
+    private boolean normalizedUriEquals(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        return equalsIgnoreCase(stripTrailingSlash(a), stripTrailingSlash(b));
+    }
+
+    /**
+     * Removes a trailing {@code /} from {@code uri} if present.
+     *
+     * @param uri URI string to normalize
+     * @return the URI without a trailing slash
+     */
+    private String stripTrailingSlash(String uri) {
+        return uri.endsWith("/") ? uri.substring(0, uri.length() - 1) : uri;
+    }
+
+    /**
+     * Strips the query string and fragment from {@code url}, returning only
+     * {@code scheme://authority/path} for htu claim comparison per RFC 9449 §4.3 rule 9.
+     *
+     * @param url the raw htu claim value from the proof
+     * @return normalized URI without query or fragment, or {@code null} if {@code url} is blank
+     * @throws DPoPProofException if {@code url} has invalid URI syntax
+     */
+    private String removeQueryAndFragment(String url) throws DPoPProofException {
+        try {
+            if (StringUtils.isBlank(url)) {
+                return null;
+            }
+            final URI uri = new URI(url);
+            return new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), null, null).toString();
+        } catch (URISyntaxException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "Invalid URI syntax in the htu claim", e);
+        }
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/util/Challenge.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/util/Challenge.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.util;
+
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
+import org.apache.axis2.AxisFault;
+import org.apache.axis2.context.MessageContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHeaders;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.wso2.carbon.apimgt.gateway.APIMgtGatewayConstants;
+import org.wso2.carbon.apimgt.gateway.handlers.Utils;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_NONCE_HEADER;
+
+/**
+ * Builds the RFC 9449 §7.1 {@code WWW-Authenticate: DPoP} challenge and dispatches a 401 Unauthorized response.
+ */
+public class Challenge {
+
+    private static final Log log = LogFactory.getLog(Challenge.class);
+
+    private final String acceptedAlgorithms;
+
+    public Challenge(String acceptedAlgorithms) {
+        this.acceptedAlgorithms = acceptedAlgorithms;
+    }
+
+    /**
+     * Sends a 401 response with a {@code WWW-Authenticate: DPoP} challenge per RFC 9449 §7.1.
+     *
+     * @param synCtx  current message context
+     * @param error   the RFC 9449 error code
+     * @param message human-readable description
+     * @param nonce   server-issued nonce to include, or {@code null}
+     */
+    public void send401(org.apache.synapse.MessageContext synCtx,
+                        DPoPProofException.ErrorCode error, String message, String nonce) {
+
+        MessageContext axis2MC = ((Axis2MessageContext) synCtx).getAxis2MessageContext();
+        axis2MC.setProperty(PassThroughConstants.MESSAGE_BUILDER_INVOKED, Boolean.TRUE);
+        try {
+            RelayUtils.consumeAndDiscardMessage(axis2MC);
+        } catch (AxisFault axisFault) {
+            log.error("Error consuming request message during DPoP 401 response", axisFault);
+        }
+
+        StringBuilder challenge = new StringBuilder("DPoP");
+        challenge.append(" error=\"").append(error.getValue()).append("\"");
+        if (message != null) {
+            challenge.append(", error_description=\"")
+                    .append(message.replace("\"", "'")).append("\"");
+        }
+        if (acceptedAlgorithms != null) {
+            challenge.append(", algs=\"").append(acceptedAlgorithms).append("\"");
+        }
+
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.put(HttpHeaders.WWW_AUTHENTICATE, challenge.toString());
+        if (nonce != null) {
+            headers.put(DPOP_NONCE_HEADER, nonce);
+            // RFC 9449 §8.2: responses carrying a nonce must not be cached.
+            headers.put(HttpHeaders.CACHE_CONTROL, DPoPConstants.CACHE_CONTROL_NO_STORE);
+        }
+        axis2MC.setProperty(MessageContext.TRANSPORT_HEADERS, headers);
+
+        synCtx.setProperty(APIMgtGatewayConstants.HTTP_RESPONSE_STATUS_CODE, 401);
+        Utils.send(synCtx, 401);
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/util/DPoPUtils.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/main/java/com/wso2/openbanking/accelerator/gateway/dpop/util/DPoPUtils.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.util;
+
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
+import org.apache.axis2.context.MessageContext;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.nhttp.NhttpConstants;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_HEADER;
+import static org.apache.commons.lang.StringUtils.equalsIgnoreCase;
+
+/**
+ * Pure helpers used across the DPoP handler — JWT inspection, transport-header
+ * access, and request-URI normalization for {@code htu} comparison.
+ */
+public final class DPoPUtils {
+
+    private static final Log log = LogFactory.getLog(DPoPUtils.class);
+
+    private static final String PROPERTY_REQUEST_PATH = "REST_FULL_REQUEST_PATH";
+    private static final String PROPERTY_TRANSPORT = "TRANSPORT_IN_NAME";
+    private static final String HEADER_HOST = "Host";
+
+    private DPoPUtils() {
+    }
+
+    /**
+     * Extracts {@code cnf.jkt} from a JWT access token without verifying the
+     * signature — signature verification is the downstream authenticator's job.
+     */
+    public static String extractJktFromJwt(String accessToken) throws DPoPProofException {
+        try {
+            JWT jwt = JWTParser.parse(accessToken);
+            JWTClaimsSet claims = jwt.getJWTClaimsSet();
+            if (claims == null) {
+                return null;
+            }
+            Object cnf = claims.getClaim(DPoPConstants.Claims.CNF_CLAIM);
+            if (cnf instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Object jkt = ((Map<String, Object>) cnf).get(DPoPConstants.Claims.JKT_CLAIM);
+                return jkt != null ? jkt.toString() : null;
+            }
+            return null;
+        } catch (ParseException e) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                    "Failed to parse JWT access token for cnf.jkt extraction: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns true if {@code token} has the three-part JWS compact structure.
+     */
+    public static boolean isJwtToken(String token) {
+
+        if (StringUtils.isBlank(token)) {
+            return false;
+        }
+        return token.split("\\.").length == 3;
+    }
+
+    /**
+     * Reconstructs and normalizes the {@code htu} (HTTP target URI) for DPoP proof
+     * verification per RFC 9449 §4.3: query string and fragment are stripped.
+     *
+     * @return {@code scheme://host/path} or {@code null} if the URI cannot be built
+     */
+    public static String normalizeHtu(org.apache.synapse.MessageContext synCtx, Map<String, String> headers) {
+        try {
+            final String authority = headers.get(HEADER_HOST);
+            final String scheme = (String) synCtx.getProperty(PROPERTY_TRANSPORT);
+            final String path = (String) synCtx.getProperty(PROPERTY_REQUEST_PATH);
+            return new URI(scheme, authority, path, null, null).toString();
+        } catch (URISyntaxException e) {
+            log.error("Unable to construct URI from message context properties. Caused by, ", e);
+            return null;
+        }
+    }
+
+    private static Map<String, String> getHeaderMapByKey(org.apache.synapse.MessageContext synCtx, String propertyKey) {
+
+        @SuppressWarnings("unchecked") final Map<String, String> headersMap =
+                (Map<String, String>) ((Axis2MessageContext) synCtx).getAxis2MessageContext().getProperty(propertyKey);
+        // Use a case-insensitive TreeMap because HTTP header names are case-insensitive
+        final Map<String, String> headersTreeMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (headersMap != null) {
+            headersTreeMap.putAll(headersMap);
+        }
+        return headersTreeMap;
+    }
+
+    /**
+     * Returns the request transport headers as a case-insensitive map.
+     */
+    public static Map<String, String> getTransportHeaders(org.apache.synapse.MessageContext synCtx) {
+
+        return getHeaderMapByKey(synCtx, MessageContext.TRANSPORT_HEADERS);
+    }
+
+    /**
+     * Returns any excess (duplicate) transport headers as a case-insensitive map.
+     * Used to detect multiple {@code DPoP} header fields per RFC 9449 §4.3.
+     */
+    public static Map<String, String> getExcessTransportHeaders(org.apache.synapse.MessageContext synCtx) {
+
+        return getHeaderMapByKey(synCtx, NhttpConstants.EXCESS_TRANSPORT_HEADERS);
+    }
+
+    /**
+     * Throws {@link DPoPProofException} if {@code htu} uses plain HTTP.
+     */
+    public static void checkHttps(final String htu) throws DPoPProofException {
+
+        if (htu != null && htu.startsWith("http://")) {
+            throw new DPoPProofException(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                    "DPoP is not permitted over plain HTTP");
+        }
+    }
+
+    /**
+     * Returns {@code true} if the message context contains more than one {@code DPoP} header field.
+     */
+    public static boolean hasMultipleDPopHeaders(org.apache.synapse.MessageContext synCtx) {
+
+        final Map<String, String> excessTransportHeaders = DPoPUtils.getExcessTransportHeaders(synCtx);
+        return !excessTransportHeaders.isEmpty() && excessTransportHeaders.containsKey(DPOP_HEADER);
+    }
+
+    /**
+     * Strips the {@code "<scheme> "} prefix from {@code authHeader} and returns the token value,
+     * or {@code null} if the header is absent or does not start with the given scheme.
+     */
+    public static String extractToken(String authHeader, String scheme) {
+        if (authHeader == null) {
+            return null;
+        }
+        String prefix = scheme + " ";
+        if (authHeader.regionMatches(true, 0, prefix, 0, prefix.length())) {
+            return authHeader.substring(prefix.length()).trim();
+        }
+        return null;
+    }
+
+    /**
+     * Removes all entries for {@code name} from {@code headers}, case-insensitively.
+     */
+    public static void removeHeader(Map<String, String> headers, String name) {
+        headers.remove(name);
+        headers.entrySet().removeIf(e -> equalsIgnoreCase(name, e.getKey()));
+    }
+
+    /**
+     * Parses a comma-separated algorithm list. Returns the default set if the input is blank.
+     */
+    public static Set<String> parseAlgorithms(String csv) {
+        String value = StringUtils.isBlank(csv) ? DPoPConstants.Defaults.ACCEPTED_ALGORITHMS : csv;
+        Set<String> result = new HashSet<>();
+        for (String alg : value.split(",")) {
+            String trimmed = alg.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        if (result.isEmpty()) {
+            return parseAlgorithms(DPoPConstants.Defaults.ACCEPTED_ALGORITHMS);
+        }
+        return result;
+    }
+
+    /**
+     * Parses {@code value} as a boolean. Returns {@code defaultValue} if {@code value} is {@code null}.
+     */
+    public static boolean parseBool(Object value, boolean defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(String.valueOf(value).trim());
+    }
+
+    /**
+     * Parses {@code value} as a long. Returns {@code defaultValue} if {@code value} is {@code null}
+     * or not a valid number.
+     */
+    public static long parseLong(Object value, long defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(String.valueOf(value).trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    /**
+     * Parses {@code value} as a trimmed string. Returns {@code defaultValue} if {@code value} is
+     * {@code null} or blank.
+     */
+    public static String parseString(Object value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        String s = String.valueOf(value).trim();
+        return s.isEmpty() ? defaultValue : s;
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandlerTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandlerTest.java
@@ -1,0 +1,637 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop;
+
+import com.wso2.openbanking.accelerator.gateway.dpop.binding.AccessTokenBinder;
+import com.wso2.openbanking.accelerator.gateway.dpop.cache.DPoPCacheProvider;
+import com.wso2.openbanking.accelerator.gateway.dpop.cache.DPoPJtiCache;
+import com.wso2.openbanking.accelerator.gateway.dpop.cache.DPoPNonceCache;
+import com.wso2.openbanking.accelerator.gateway.dpop.cache.LocalDPoPCacheProvider;
+import com.wso2.openbanking.accelerator.gateway.dpop.nonce.NonceStrategy;
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofValidator;
+import com.wso2.openbanking.accelerator.gateway.dpop.util.Challenge;
+import com.wso2.openbanking.accelerator.gateway.dpop.util.DPoPUtils;
+import com.wso2.openbanking.accelerator.gateway.internal.GatewayDataHolder;
+import org.apache.axis2.Constants;
+import org.apache.axis2.context.MessageContext;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link DPoPHandler}. All private collaborator fields are injected
+ * via reflection so that {@code init()} — which requires Carbon/APIM runtime — is
+ * never called for the request-flow tests.
+ * <p>
+ * {@code @PrepareForTest} lists every class for which we need static or constructor
+ * mocking across this suite: {@link DPoPUtils} (static helpers), {@link GatewayDataHolder}
+ * (singleton accessor), and {@link LocalDPoPCacheProvider} (calls {@code new} on the
+ * cache classes during init).
+ */
+@PrepareForTest({DPoPUtils.class, GatewayDataHolder.class, LocalDPoPCacheProvider.class})
+public class DPoPHandlerTest extends PowerMockTestCase {
+
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String HEADER_DPOP = "DPoP";
+    private static final String BEARER_TAG = "Bearer ";
+    private static final String DPOP_SCHEME = "DPoP";
+    private static final String ACCESS_TOKEN = "test-access-token";
+    private static final String DPOP_PROOF = "dpop.proof.jwt";
+    private static final String JWK_THUMBPRINT = "some-jwk-thumbprint";
+    private static final String JTI = "unique-jti";
+    private static final String HTU = "https://api.example.com/resource";
+    private static final String HTTP_METHOD = "GET";
+    private static final long JTI_TTL = 120L;
+
+    private DPoPHandler handler;
+    private DPoPProofValidator mockValidator;
+    private DPoPCacheProvider mockCache;
+    private AccessTokenBinder mockBinder;
+    private Challenge mockChallenge;
+    private NonceStrategy mockNonceStrategy;
+
+    private org.apache.synapse.core.axis2.Axis2MessageContext mockSynCtx;
+    private MessageContext mockAxis2MC;
+
+    @BeforeClass
+    public void beforeClass() {
+        System.setProperty("carbon.home", "/");
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        handler = new DPoPHandler();
+        mockValidator = Mockito.mock(DPoPProofValidator.class);
+        mockCache = Mockito.mock(DPoPCacheProvider.class);
+        mockBinder = Mockito.mock(AccessTokenBinder.class);
+        mockChallenge = Mockito.mock(Challenge.class);
+        mockNonceStrategy = Mockito.mock(NonceStrategy.class);
+
+        // Inject all fields without calling init()
+        setField("apiDPoPEnabled", true);
+        setField("iatSkewSeconds", 60L);
+        setField("jtiCacheTtlSeconds", JTI_TTL);
+        setField("stripDpopHeader", false);
+        setField("httpsRequired", false);
+        setField("proofValidator", mockValidator);
+        setField("cacheProvider", mockCache);
+        setField("accessTokenBinder", mockBinder);
+        setField("challenge", mockChallenge);
+        setField("nonceStrategy", mockNonceStrategy);
+
+        // Default: nonce not required, no rotation
+        Mockito.when(mockNonceStrategy.requiresNonce(Mockito.anyString())).thenReturn(false);
+        Mockito.when(mockNonceStrategy.shouldRotate(Mockito.anyString())).thenReturn(false);
+
+        mockSynCtx = Mockito.mock(org.apache.synapse.core.axis2.Axis2MessageContext.class);
+        mockAxis2MC = Mockito.mock(MessageContext.class);
+        Mockito.when(mockSynCtx.getAxis2MessageContext()).thenReturn(mockAxis2MC);
+    }
+
+    @Test
+    public void apiDPoPDisabledShouldPassThrough() throws Exception {
+        setField("apiDPoPEnabled", false);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        Mockito.verifyZeroInteractions(mockValidator, mockCache, mockBinder, mockChallenge);
+    }
+
+    @Test
+    public void noTransportHeadersShouldPassThrough() {
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx))
+                .thenReturn(new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER));
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void bearerTokenWithNoDPoPHeaderAndNoJktShouldPassThrough() throws Exception {
+        Map<String, String> headers = makeHeaders(AUTH_HEADER, BEARER_TAG + ACCESS_TOKEN);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(BEARER_TAG + ACCESS_TOKEN, "Bearer"))
+                .thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        Mockito.verify(mockChallenge, Mockito.never())
+                .send401(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void dpopBoundBearerTokenWithoutProofShouldReject() throws Exception {
+        // No DPoP header, but token has cnf.jkt
+        Map<String, String> headers = makeHeaders(AUTH_HEADER, BEARER_TAG + ACCESS_TOKEN);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(BEARER_TAG + ACCESS_TOKEN, "Bearer"))
+                .thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertFalse(result);
+        Mockito.verify(mockChallenge).send401(
+                Mockito.eq(mockSynCtx),
+                Mockito.eq(DPoPProofException.ErrorCode.INVALID_TOKEN),
+                Mockito.any(String.class),
+                (String) Mockito.isNull());
+    }
+
+    @Test
+    public void validDPoPRequestShouldSucceedAndRewriteAuthHeader() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn("kid-1");
+
+        DPoPProofValidator.ValidationResult mockResult =
+                Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD))
+                .thenReturn(HTTP_METHOD);
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, null))
+                .thenReturn(mockResult);
+        Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+        Mockito.doNothing().when(mockBinder).verifyBinding(JWK_THUMBPRINT, JWK_THUMBPRINT);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        Mockito.verify(mockChallenge, Mockito.never())
+                .send401(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void parseDPoPProofExceptionShouldSend401AndReturnFalse() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF))
+                .thenThrow(new DPoPProofException(
+                        DPoPProofException.ErrorCode.INVALID_DPOP_PROOF, "Bad proof"));
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertFalse(result);
+        Mockito.verify(mockChallenge).send401(
+                Mockito.eq(mockSynCtx),
+                Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                Mockito.any(String.class),
+                (String) Mockito.isNull());
+    }
+
+    @Test
+    public void nonceRequiredButAbsentShouldIssueNonceAndSend401() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        String issuedNonce = "fresh-server-nonce";
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD))
+                .thenReturn(HTTP_METHOD);
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+        // Nonce is required but no active nonce exists
+        Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(true);
+        Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(null);
+        Mockito.when(mockCache.issueNonce(JWK_THUMBPRINT)).thenReturn(issuedNonce);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertFalse(result);
+        Mockito.verify(mockCache).issueNonce(JWK_THUMBPRINT);
+        Mockito.verify(mockChallenge).send401(
+                Mockito.eq(mockSynCtx),
+                Mockito.eq(DPoPProofException.ErrorCode.USE_DPOP_NONCE),
+                Mockito.any(String.class),
+                Mockito.eq(issuedNonce));
+    }
+
+    @Test
+    public void jtiReplayShouldRejectRequest() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult =
+                Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD))
+                .thenReturn(HTTP_METHOD);
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, null))
+                .thenReturn(mockResult);
+        // Replay: isJtiFirstUse returns false
+        Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(false);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertFalse(result);
+        Mockito.verify(mockChallenge).send401(
+                Mockito.eq(mockSynCtx),
+                Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                Mockito.any(String.class),
+                (String) Mockito.isNull());
+    }
+
+    @Test
+    public void multipleDPoPHeadersShouldRejectRequest() throws Exception {
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        // Multiple DPoP headers
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(true);
+
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(JWK_THUMBPRINT);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertFalse(result);
+        Mockito.verify(mockChallenge).send401(
+                Mockito.eq(mockSynCtx),
+                Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                Mockito.any(String.class),
+                (String) Mockito.isNull());
+    }
+
+    @Test
+    public void handleResponseShouldAlwaysReturnTrue() {
+        assertTrue(handler.handleResponse(mockSynCtx));
+    }
+
+    @Test
+    public void initShouldBuildCollaboratorsUsingDefaultsWhenServiceUnavailable() throws Exception {
+        PowerMockito.mockStatic(GatewayDataHolder.class);
+        GatewayDataHolder mockHolder = Mockito.mock(GatewayDataHolder.class);
+        Mockito.when(mockHolder.getOpenBankingConfigurationService()).thenReturn(null);
+        PowerMockito.when(GatewayDataHolder.getInstance()).thenReturn(mockHolder);
+
+        // Intercept the cache-class constructions performed by LocalDPoPCacheProvider#initialize
+        DPoPJtiCache stubJti = Mockito.mock(DPoPJtiCache.class);
+        DPoPNonceCache stubNonce = Mockito.mock(DPoPNonceCache.class);
+        PowerMockito.whenNew(DPoPJtiCache.class).withAnyArguments().thenReturn(stubJti);
+        PowerMockito.whenNew(DPoPNonceCache.class).withAnyArguments().thenReturn(stubNonce);
+
+        handler.init(Mockito.mock(SynapseEnvironment.class));
+    }
+
+    @Test
+    public void destroyShouldCompleteWithoutError() {
+        handler.destroy();
+    }
+
+    @Test
+    public void dpopSchemeWithoutProofHeaderShouldRejectWithInvalidProof() throws Exception {
+        Map<String, String> headers = makeHeaders(AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertFalse(result);
+        Mockito.verify(mockChallenge).send401(
+                Mockito.eq(mockSynCtx),
+                Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                Mockito.any(String.class),
+                (String) Mockito.isNull());
+    }
+
+    @Test
+    public void httpsRequiredShouldRejectPlainHttpRequest() throws Exception {
+        setField("httpsRequired", true);
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers))
+                .thenReturn("http://api.example.com/resource");
+        // checkHttps is void → use doThrow on a static method via the PowerMock pattern
+        PowerMockito.doThrow(new DPoPProofException(
+                        DPoPProofException.ErrorCode.INVALID_DPOP_PROOF, "HTTPS required"))
+                .when(DPoPUtils.class);
+        DPoPUtils.checkHttps("http://api.example.com/resource");
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertFalse(result);
+        Mockito.verify(mockChallenge).send401(
+                Mockito.eq(mockSynCtx),
+                Mockito.eq(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF),
+                Mockito.any(String.class), (String) Mockito.isNull());
+    }
+
+    @Test
+    public void validDPoPRequestWithNonceShouldReuseNonceWhenRotationNotNeeded() throws Exception {
+        // RFC 9449 §11.4: same nonce may be reused; no new nonce is issued when shouldRotate=false.
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+        String activeNonce = "server-issued-nonce";
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult =
+                Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+        Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(true);
+        Mockito.when(mockNonceStrategy.shouldRotate(JWK_THUMBPRINT)).thenReturn(false);
+        Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(activeNonce);
+        Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, activeNonce))
+                .thenReturn(mockResult);
+        Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+        Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        // No new nonce issued — nonce is reused until the strategy says rotate
+        Mockito.verify(mockCache, Mockito.never()).issueNonce(Mockito.anyString());
+        Mockito.verify(mockSynCtx, Mockito.never())
+                .setProperty(Mockito.eq(DPoPConstants.DPOP_RESPONSE_NONCE_PROPERTY), Mockito.any());
+    }
+
+    @Test
+    public void validDPoPRequestShouldRotateNonceInResponseWhenStrategyDecides() throws Exception {
+        // RFC 9449 §8.2: proactively deliver fresh nonce in 200 response when strategy rotates.
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+        String activeNonce = "current-nonce";
+        String rotatedNonce = "rotated-nonce";
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult =
+                Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+        Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(true);
+        Mockito.when(mockNonceStrategy.shouldRotate(JWK_THUMBPRINT)).thenReturn(true);
+        Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(activeNonce);
+        Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, activeNonce))
+                .thenReturn(mockResult);
+        Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+        Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+        Mockito.when(mockCache.issueNonce(JWK_THUMBPRINT)).thenReturn(rotatedNonce);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        Mockito.verify(mockCache).issueNonce(JWK_THUMBPRINT);
+        Mockito.verify(mockSynCtx).setProperty(DPoPConstants.DPOP_RESPONSE_NONCE_PROPERTY, rotatedNonce);
+    }
+
+    @Test
+    public void section11_3ActiveNonceWithoutStrategyRequirementShouldEnforceNonce() throws Exception {
+        // RFC 9449 §11.3: if an active nonce exists, the handler must require it even when
+        // the strategy's requiresNonce() returns false (e.g. after a strategy switch).
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+        String orphanNonce = "orphan-active-nonce";
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult =
+                Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+        // Strategy says no nonce required, but an active nonce exists
+        Mockito.when(mockNonceStrategy.requiresNonce(JWK_THUMBPRINT)).thenReturn(false);
+        Mockito.when(mockCache.getActiveNonce(JWK_THUMBPRINT)).thenReturn(orphanNonce);
+        // Validation is called with the active nonce — §11.3 is enforced via activeNonce != null
+        Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, orphanNonce))
+                .thenReturn(mockResult);
+        Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+        Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        // Nonce was enforced despite requiresNonce=false — §11.3 compliant
+        Mockito.verify(mockValidator).validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, orphanNonce);
+    }
+
+    @Test
+    public void validDPoPRequestShouldStripDPoPHeaderWhenConfigured() throws Exception {
+        setField("stripDpopHeader", true);
+        Map<String, String> headers = makeHeaders(
+                AUTH_HEADER, DPOP_SCHEME + " " + ACCESS_TOKEN,
+                HEADER_DPOP, DPOP_PROOF);
+
+        DPoPProofValidator.ParsedProof mockParsed = Mockito.mock(DPoPProofValidator.ParsedProof.class);
+        Mockito.when(mockParsed.getJwkThumbprint()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockParsed.getKid()).thenReturn(null);
+
+        DPoPProofValidator.ValidationResult mockResult =
+                Mockito.mock(DPoPProofValidator.ValidationResult.class);
+        Mockito.when(mockResult.getProofJkt()).thenReturn(JWK_THUMBPRINT);
+        Mockito.when(mockResult.getJti()).thenReturn(JTI);
+
+        PowerMockito.mockStatic(DPoPUtils.class);
+        PowerMockito.when(DPoPUtils.getTransportHeaders(mockSynCtx)).thenReturn(headers);
+        PowerMockito.when(DPoPUtils.extractToken(
+                DPOP_SCHEME + " " + ACCESS_TOKEN, DPOP_SCHEME)).thenReturn(ACCESS_TOKEN);
+        PowerMockito.when(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx)).thenReturn(false);
+        PowerMockito.when(DPoPUtils.normalizeHtu(mockSynCtx, headers)).thenReturn(HTU);
+
+        Mockito.when(mockAxis2MC.getProperty(Constants.Configuration.HTTP_METHOD)).thenReturn(HTTP_METHOD);
+        Mockito.when(mockValidator.parseDPoPProof(DPOP_PROOF)).thenReturn(mockParsed);
+        Mockito.when(mockBinder.resolveJkt(ACCESS_TOKEN)).thenReturn(null);
+        Mockito.when(mockValidator.validate(mockParsed, HTTP_METHOD, HTU, ACCESS_TOKEN, null))
+                .thenReturn(mockResult);
+        Mockito.when(mockCache.isJtiFirstUse(JTI, JWK_THUMBPRINT, JTI_TTL)).thenReturn(true);
+        Mockito.doNothing().when(mockBinder).verifyBinding(null, JWK_THUMBPRINT);
+
+        boolean result = handler.handleRequest(mockSynCtx);
+
+        assertTrue(result);
+        PowerMockito.verifyStatic();
+        DPoPUtils.removeHeader(headers, HEADER_DPOP);
+    }
+
+    private Map<String, String> makeHeaders(String... keyValues) {
+        Map<String, String> map = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+        for (int i = 0; i < keyValues.length - 1; i += 2) {
+            map.put(keyValues[i], keyValues[i + 1]);
+        }
+        return map;
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field field = findField(handler.getClass(), name);
+        field.setAccessible(true);
+        field.set(handler, value);
+    }
+
+    private Field findField(Class<?> clazz, String name) throws NoSuchFieldException {
+        try {
+            return clazz.getDeclaredField(name);
+        } catch (NoSuchFieldException e) {
+            if (clazz.getSuperclass() != null) {
+                return findField(clazz.getSuperclass(), name);
+            }
+            throw e;
+        }
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandlerTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/DPoPHandlerTest.java
@@ -34,6 +34,7 @@ import org.apache.axis2.context.MessageContext;
 import org.apache.synapse.core.SynapseEnvironment;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeClass;
@@ -57,7 +58,8 @@ import static org.testng.Assert.assertTrue;
  * (singleton accessor), and {@link LocalDPoPCacheProvider} (calls {@code new} on the
  * cache classes during init).
  */
-@PrepareForTest({DPoPUtils.class, GatewayDataHolder.class, LocalDPoPCacheProvider.class})
+@PrepareForTest({DPoPUtils.class, GatewayDataHolder.class, LocalDPoPCacheProvider.class, DPoPProofValidator.class})
+@PowerMockIgnore({"jdk.internal.reflect.*", "javax.management.*"})
 public class DPoPHandlerTest extends PowerMockTestCase {
 
     private static final String AUTH_HEADER = "Authorization";

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/AccessTokenBinderTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/AccessTokenBinderTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.binding;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.ThumbprintUtils;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.SHA256_HASH_ALG;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * Unit tests for {@link AccessTokenBinder}. Covers JWT and opaque-token paths
+ * and the mismatch / missing-binding error cases.
+ */
+public class AccessTokenBinderTest {
+
+    private ECKey ecKey;
+    private String correctJkt;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        ecKey = new ECKeyGenerator(Curve.P_256).generate();
+        correctJkt = ThumbprintUtils.compute(SHA256_HASH_ALG, ecKey.toPublicJWK()).toString();
+    }
+
+    @Test
+    public void jwtWithMatchingJktShouldPass() throws Exception {
+        String jwtToken = buildJwtWithCnf(ecKey, correctJkt);
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(null));
+
+        String tokenJkt = binder.resolveJkt(jwtToken);
+        binder.verifyBinding(tokenJkt, correctJkt);
+    }
+
+    @Test
+    public void jwtWithMismatchedJktShouldFail() throws Exception {
+        ECKey otherKey = new ECKeyGenerator(Curve.P_256).generate();
+        String otherJkt = ThumbprintUtils.compute(SHA256_HASH_ALG, otherKey.toPublicJWK()).toString();
+        String jwtToken = buildJwtWithCnf(ecKey, otherJkt);
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(null));
+
+        String tokenJkt = binder.resolveJkt(jwtToken);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_TOKEN, () -> binder.verifyBinding(tokenJkt, correctJkt));
+    }
+
+    @Test
+    public void jwtWithoutCnfClaimShouldFail() throws Exception {
+        String jwtToken = buildJwtWithoutCnf();
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(null));
+
+        String tokenJkt = binder.resolveJkt(jwtToken);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                () -> binder.verifyBinding(tokenJkt, correctJkt));
+    }
+
+    @Test
+    public void opaqueTokenWithMatchingJktShouldPass() throws Exception {
+        String opaqueToken = "opaque_token_no_dots";
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(correctJkt));
+
+        String tokenJkt = binder.resolveJkt(opaqueToken);
+        binder.verifyBinding(tokenJkt, correctJkt);
+    }
+
+    @Test
+    public void opaqueTokenWithMismatchedJktShouldFail() throws Exception {
+        String opaqueToken = "opaque_token_no_dots";
+        ECKey otherKey = new ECKeyGenerator(Curve.P_256).generate();
+        String otherJkt = ThumbprintUtils.compute(SHA256_HASH_ALG, otherKey.toPublicJWK()).toString();
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(otherJkt));
+
+        String tokenJkt = binder.resolveJkt(opaqueToken);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                () -> binder.verifyBinding(tokenJkt, correctJkt));
+    }
+
+    @Test
+    public void opaqueTokenWithNoJktShouldFail() throws Exception {
+        String opaqueToken = "opaque_token_no_dots";
+        AccessTokenBinder binder = new AccessTokenBinder(mockIntrospection(null));
+
+        String tokenJkt = binder.resolveJkt(opaqueToken);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_TOKEN,
+                () -> binder.verifyBinding(tokenJkt, correctJkt));
+    }
+
+    private String buildJwtWithCnf(ECKey key, String jkt) throws Exception {
+        Map<String, Object> cnf = new HashMap<>();
+        cnf.put(DPoPConstants.Claims.JKT_CLAIM, jkt);
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .claim(DPoPConstants.Claims.CNF_CLAIM, cnf)
+                .subject("test-client")
+                .build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(key));
+        return jwt.serialize();
+    }
+
+    private String buildJwtWithoutCnf() throws Exception {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder().subject("test-client").build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(ecKey));
+        return jwt.serialize();
+    }
+
+    private IntrospectionClient mockIntrospection(String jkt) throws Exception {
+        IntrospectionClient mock = Mockito.mock(IntrospectionClient.class);
+        Mockito.when(mock.getJwkThumbprint(Mockito.anyString())).thenReturn(jkt);
+        return mock;
+    }
+
+    private void assertErrorCode(DPoPProofException.ErrorCode expected, ThrowingRunnable call) {
+        try {
+            call.run();
+            fail("Expected DPoPProofException with error code " + expected);
+        } catch (DPoPProofException e) {
+            assertEquals(e.getErrorCode(), expected);
+        } catch (Exception e) {
+            fail("Unexpected exception: " + e);
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/IntrospectionClientTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/IntrospectionClientTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.binding;
+
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.AccessTokenInfo;
+import org.wso2.carbon.apimgt.api.model.KeyManager;
+import org.wso2.carbon.apimgt.impl.dto.KeyManagerDto;
+import org.wso2.carbon.apimgt.impl.factory.KeyManagerHolder;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
+
+/**
+ * Unit tests for {@link IntrospectionClient}. Mocks the static {@link PrivilegedCarbonContext}
+ * and {@link KeyManagerHolder} entry points so the tests run without a Carbon runtime.
+ */
+@PrepareForTest({PrivilegedCarbonContext.class, KeyManagerHolder.class})
+public class IntrospectionClientTest extends PowerMockTestCase {
+
+    private static final String TENANT = "carbon.super";
+    private static final String TOKEN = "opaque-access-token";
+    private static final String JKT = "some-jwk-thumbprint-value";
+    private static final long CACHE_TTL = 60L;
+
+    @BeforeClass
+    public void beforeClass() {
+        // Required so Carbon context static initializers can run before PowerMock intercepts them.
+        System.setProperty("carbon.home", "/");
+    }
+
+    @BeforeMethod
+    public void setUpStaticMocks() {
+        PowerMockito.mockStatic(PrivilegedCarbonContext.class);
+        PowerMockito.mockStatic(KeyManagerHolder.class);
+
+        PrivilegedCarbonContext mockPcc = Mockito.mock(PrivilegedCarbonContext.class);
+        PowerMockito.when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(mockPcc);
+        Mockito.when(mockPcc.getTenantDomain(true)).thenReturn(TENANT);
+    }
+
+    @Test
+    public void secondCallShouldUseCacheAndNotIntrospect() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        KeyManager mockKm = buildKeyManager(TOKEN, JKT);
+        PowerMockito.when(KeyManagerHolder.getTenantKeyManagers(TENANT))
+                .thenReturn(buildKmDtoMap(mockKm));
+
+        // First call triggers introspection
+        String first = client.getJwkThumbprint(TOKEN);
+        assertEquals(first, JKT);
+
+        // Second call must hit the cache — KeyManagerHolder must NOT be called again
+        String second = client.getJwkThumbprint(TOKEN);
+        assertEquals(second, JKT);
+
+        PowerMockito.verifyStatic(Mockito.times(1));
+        KeyManagerHolder.getTenantKeyManagers(TENANT);
+    }
+
+    @Test
+    public void cacheMissWithJktShouldReturnThumbprint() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        KeyManager mockKm = buildKeyManager(TOKEN, JKT);
+        PowerMockito.when(KeyManagerHolder.getTenantKeyManagers(TENANT))
+                .thenReturn(buildKmDtoMap(mockKm));
+
+        String result = client.getJwkThumbprint(TOKEN);
+
+        assertEquals(result, JKT);
+    }
+
+    // ─── Cache miss, token valid but no cnf claim → null not cached ───────────
+
+    @Test
+    public void cacheMissWithNoCnfShouldReturnNullAndNotCache() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        KeyManager mockKm = buildKeyManagerNoCnf(TOKEN);
+        PowerMockito.when(KeyManagerHolder.getTenantKeyManagers(TENANT))
+                .thenReturn(buildKmDtoMap(mockKm));
+
+        String first = client.getJwkThumbprint(TOKEN);
+        assertNull(first);
+
+        // Second call should also call introspection (null was not cached)
+        String second = client.getJwkThumbprint(TOKEN);
+        assertNull(second);
+
+        PowerMockito.verifyStatic(Mockito.times(2));
+        KeyManagerHolder.getTenantKeyManagers(TENANT);
+    }
+
+    // ─── APIManagementException from one KM → tries next; all fail → throws ──
+
+    @Test
+    public void allKeyManagersThrowingShouldThrowIntrospectionException() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        KeyManager throwingKm = Mockito.mock(KeyManager.class);
+        Mockito.when(throwingKm.getTokenMetaData(TOKEN))
+                .thenThrow(new APIManagementException("service unavailable"));
+        PowerMockito.when(KeyManagerHolder.getTenantKeyManagers(TENANT))
+                .thenReturn(buildKmDtoMap(throwingKm));
+
+        try {
+            client.getJwkThumbprint(TOKEN);
+            fail("Expected IntrospectionException");
+        } catch (IntrospectionClient.IntrospectionException e) {
+            // expected — all key managers exhausted
+        }
+    }
+
+    @Test
+    public void noKeyManagersConfiguredShouldThrowIntrospectionException() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        PowerMockito.when(KeyManagerHolder.getTenantKeyManagers(TENANT))
+                .thenReturn(Collections.<String, KeyManagerDto>emptyMap());
+
+        try {
+            client.getJwkThumbprint(TOKEN);
+            fail("Expected IntrospectionException");
+        } catch (IntrospectionClient.IntrospectionException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void nullAccessTokenInfoShouldContinueToNextKeyManager() throws Exception {
+        IntrospectionClient client = new IntrospectionClient(CACHE_TTL);
+
+        // First KM returns null; second returns a valid result with jkt
+        KeyManager nullKm = Mockito.mock(KeyManager.class);
+        Mockito.when(nullKm.getTokenMetaData(TOKEN)).thenReturn(null);
+
+        KeyManager validKm = buildKeyManager(TOKEN, JKT);
+
+        Map<String, KeyManagerDto> dtoMap = new HashMap<String, KeyManagerDto>();
+        dtoMap.put("nullKm", buildDto(nullKm));
+        dtoMap.put("validKm", buildDto(validKm));
+
+        PowerMockito.when(KeyManagerHolder.getTenantKeyManagers(TENANT)).thenReturn(dtoMap);
+
+        String result = client.getJwkThumbprint(TOKEN);
+        assertEquals(result, JKT);
+    }
+
+    private KeyManager buildKeyManager(String token, String jkt) throws APIManagementException {
+        Map<String, Object> cnf = new HashMap<String, Object>();
+        cnf.put(DPoPConstants.Claims.JKT_CLAIM, jkt);
+
+        AccessTokenInfo tokenInfo = Mockito.mock(AccessTokenInfo.class);
+        Mockito.when(tokenInfo.isTokenValid()).thenReturn(true);
+        Mockito.when(tokenInfo.getParameter(DPoPConstants.Claims.CNF_CLAIM)).thenReturn(cnf);
+
+        KeyManager km = Mockito.mock(KeyManager.class);
+        Mockito.when(km.getTokenMetaData(token)).thenReturn(tokenInfo);
+        return km;
+    }
+
+    private KeyManager buildKeyManagerNoCnf(String token) throws APIManagementException {
+        AccessTokenInfo tokenInfo = Mockito.mock(AccessTokenInfo.class);
+        Mockito.when(tokenInfo.isTokenValid()).thenReturn(true);
+        Mockito.when(tokenInfo.getParameter(DPoPConstants.Claims.CNF_CLAIM)).thenReturn(null);
+
+        KeyManager km = Mockito.mock(KeyManager.class);
+        Mockito.when(km.getTokenMetaData(token)).thenReturn(tokenInfo);
+        return km;
+    }
+
+    private Map<String, KeyManagerDto> buildKmDtoMap(KeyManager km) {
+        return Collections.singletonMap("defaultKm", buildDto(km));
+    }
+
+    private KeyManagerDto buildDto(KeyManager km) {
+        KeyManagerDto dto = new KeyManagerDto();
+        dto.setKeyManager(km);
+        return dto;
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/IntrospectionClientTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/binding/IntrospectionClientTest.java
@@ -21,6 +21,7 @@ package com.wso2.openbanking.accelerator.gateway.dpop.binding;
 import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeClass;
@@ -46,6 +47,7 @@ import static org.testng.Assert.fail;
  * and {@link KeyManagerHolder} entry points so the tests run without a Carbon runtime.
  */
 @PrepareForTest({PrivilegedCarbonContext.class, KeyManagerHolder.class})
+@PowerMockIgnore({"jdk.internal.reflect.*", "javax.management.*"})
 public class IntrospectionClientTest extends PowerMockTestCase {
 
     private static final String TENANT = "carbon.super";

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/LocalDPoPCacheProviderTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/LocalDPoPCacheProviderTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.cache;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.anyLong;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link LocalDPoPCacheProvider}. Uses reflection to inject mocked
+ * {@link DPoPJtiCache} and {@link DPoPNonceCache} so that {@code initialize()} —
+ * which would otherwise build real Carbon-backed caches — is bypassed.
+ * <p>
+ * {@code @PrepareForTest(LocalDPoPCacheProvider.class)} is required so PowerMock
+ * can intercept the {@code new DPoPJtiCache(...)} / {@code new DPoPNonceCache(...)}
+ * calls inside {@code initialize()} (PowerMock instruments the calling class).
+ */
+@PrepareForTest({LocalDPoPCacheProvider.class})
+public class LocalDPoPCacheProviderTest extends PowerMockTestCase {
+
+    private static final String KEY_ID = "test-proof-key-id";
+    private static final String JTI = "unique-jti-value";
+    private static final String JKT = "some-jwk-thumbprint";
+    private static final long TTL = 120L;
+
+    private LocalDPoPCacheProvider provider;
+    private DPoPJtiCache mockJtiCache;
+    private DPoPNonceCache mockNonceCache;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        provider = new LocalDPoPCacheProvider();
+        mockJtiCache = Mockito.mock(DPoPJtiCache.class);
+        mockNonceCache = Mockito.mock(DPoPNonceCache.class);
+        injectField(provider, "jtiCache", mockJtiCache);
+        injectField(provider, "nonceCache", mockNonceCache);
+    }
+
+    // ─── isJtiFirstUse ────────────────────────────────────────────────────────
+
+    @Test
+    public void isJtiFirstUseShouldReturnTrueOnFirstSeen() {
+        Mockito.when(mockJtiCache.isJtiFirstUse(JTI, JKT)).thenReturn(true);
+
+        boolean result = provider.isJtiFirstUse(JTI, JKT, TTL);
+
+        assertTrue(result);
+        Mockito.verify(mockJtiCache).isJtiFirstUse(JTI, JKT);
+    }
+
+    @Test
+    public void isJtiFirstUseShouldReturnFalseOnReplay() {
+        Mockito.when(mockJtiCache.isJtiFirstUse(JTI, JKT)).thenReturn(false);
+
+        boolean result = provider.isJtiFirstUse(JTI, JKT, TTL);
+
+        assertFalse(result);
+        Mockito.verify(mockJtiCache).isJtiFirstUse(JTI, JKT);
+    }
+
+    @Test
+    public void issueNonceShouldReturnNonBlankValue() {
+        String nonce = provider.issueNonce(KEY_ID);
+
+        assertNotNull(nonce);
+        assertFalse(StringUtils.isBlank(nonce));
+    }
+
+    @Test
+    public void issueNonceShouldCallNonceCacheStoreNonce() {
+        String nonce = provider.issueNonce(KEY_ID);
+
+        Mockito.verify(mockNonceCache).storeNonce(Mockito.eq(KEY_ID), Mockito.eq(nonce));
+    }
+
+    @Test
+    public void consecutiveIssueNonceCallsShouldReturnDifferentValues() {
+        String first = provider.issueNonce(KEY_ID);
+        String second = provider.issueNonce(KEY_ID);
+
+        assertNotEquals(first, second,
+                "Two consecutive nonces for the same key should differ (SecureRandom-backed)");
+    }
+
+    @Test
+    public void getActiveNonceShouldDelegateToNonceCache() {
+        String expected = "active-nonce-value";
+        Mockito.when(mockNonceCache.getActiveNonce(KEY_ID)).thenReturn(expected);
+
+        String result = provider.getActiveNonce(KEY_ID);
+
+        Mockito.verify(mockNonceCache).getActiveNonce(KEY_ID);
+        org.testng.Assert.assertEquals(result, expected);
+    }
+
+    @Test
+    public void getActiveNonceShouldReturnNullWhenNoneIssued() {
+        Mockito.when(mockNonceCache.getActiveNonce(KEY_ID)).thenReturn(null);
+
+        String result = provider.getActiveNonce(KEY_ID);
+
+        assertNull(result);
+    }
+
+    // ─── initialize() — verifies the caches are constructed via PowerMock whenNew ──
+
+    @Test
+    public void initializeShouldCreateCachesWithProvidedTtl() throws Exception {
+        DPoPJtiCache stubJti = Mockito.mock(DPoPJtiCache.class);
+        DPoPNonceCache stubNonce = Mockito.mock(DPoPNonceCache.class);
+        PowerMockito.whenNew(DPoPJtiCache.class).withAnyArguments().thenReturn(stubJti);
+        PowerMockito.whenNew(DPoPNonceCache.class).withAnyArguments().thenReturn(stubNonce);
+
+        Map<String, Object> props = new HashMap<>();
+        props.put("JtiCacheTtlSeconds", "180");
+        props.put("NonceTtlSeconds", "600");
+
+        new LocalDPoPCacheProvider().initialize(props);
+
+        PowerMockito.verifyNew(DPoPJtiCache.class).withArguments(180L);
+        PowerMockito.verifyNew(DPoPNonceCache.class).withArguments(600L);
+    }
+
+    @Test
+    public void initializeShouldUseDefaultsWhenPropertiesAbsent() throws Exception {
+        DPoPJtiCache stubJti = Mockito.mock(DPoPJtiCache.class);
+        DPoPNonceCache stubNonce = Mockito.mock(DPoPNonceCache.class);
+        PowerMockito.whenNew(DPoPJtiCache.class).withAnyArguments().thenReturn(stubJti);
+        PowerMockito.whenNew(DPoPNonceCache.class).withAnyArguments().thenReturn(stubNonce);
+
+        new LocalDPoPCacheProvider().initialize(new HashMap<>());
+
+        // verifyNew(Class).withAnyArguments() defaults to times(1).
+        PowerMockito.verifyNew(DPoPJtiCache.class).withArguments(anyLong());
+        PowerMockito.verifyNew(DPoPNonceCache.class).withArguments(anyLong());
+    }
+
+    @Test
+    public void initializeShouldFallbackToDefaultForInvalidTtlValue() throws Exception {
+        DPoPJtiCache stubJti = Mockito.mock(DPoPJtiCache.class);
+        DPoPNonceCache stubNonce = Mockito.mock(DPoPNonceCache.class);
+        PowerMockito.whenNew(DPoPJtiCache.class).withAnyArguments().thenReturn(stubJti);
+        PowerMockito.whenNew(DPoPNonceCache.class).withAnyArguments().thenReturn(stubNonce);
+
+        Map<String, Object> props = new HashMap<>();
+        props.put("JtiCacheTtlSeconds", "not-a-number");
+
+        new LocalDPoPCacheProvider().initialize(props);
+
+        PowerMockito.verifyNew(DPoPJtiCache.class).withArguments(anyLong());
+    }
+
+    private static void injectField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/LocalDPoPCacheProviderTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/cache/LocalDPoPCacheProviderTest.java
@@ -21,6 +21,7 @@ package com.wso2.openbanking.accelerator.gateway.dpop.cache;
 import org.apache.commons.lang3.StringUtils;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
@@ -47,6 +48,7 @@ import static org.testng.Assert.assertTrue;
  * calls inside {@code initialize()} (PowerMock instruments the calling class).
  */
 @PrepareForTest({LocalDPoPCacheProvider.class})
+@PowerMockIgnore({"jdk.internal.reflect.*", "javax.management.*"})
 public class LocalDPoPCacheProviderTest extends PowerMockTestCase {
 
     private static final String KEY_ID = "test-proof-key-id";

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NonceStrategyTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NonceStrategyTest.java
@@ -63,7 +63,7 @@ public class NonceStrategyTest {
     @Test
     public void rotatingStrategyShouldAlwaysRequireNonce() {
         // requiresNonce is pure/side-effect-free — always true regardless of call count.
-        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3);
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3, 10_000);
         String client = "client-x";
         assertTrue(strategy.requiresNonce(client));
         assertTrue(strategy.requiresNonce(client));
@@ -74,7 +74,7 @@ public class NonceStrategyTest {
 
     @Test
     public void rotatingStrategyShouldRotateAtModuloIntervals() {
-        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3);
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3, 10_000);
         String client = "client-y";
 
         assertFalse(strategy.shouldRotate(client)); // count=1
@@ -88,7 +88,7 @@ public class NonceStrategyTest {
     @Test
     public void rotatingStrategyShouldFloorRotateAfterUsesAtOne() {
         // A misconfiguration of 0 or negative must not cause a div-by-zero in the strategy.
-        RotatingNonceStrategy strategy = new RotatingNonceStrategy(0);
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(0, 10_000);
         // rotateAfterUses is floored to 1 — every validated proof triggers rotation
         assertTrue(strategy.shouldRotate("c")); // count=1 → 1%1==0
         assertTrue(strategy.shouldRotate("c")); // count=2 → 2%1==0

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NonceStrategyTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/nonce/NonceStrategyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.nonce;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for the three built-in {@link NonceStrategy} implementations.
+ */
+public class NonceStrategyTest {
+
+    @Test
+    public void neverStrategyShouldNeverRequireNonce() {
+        NeverNonceStrategy strategy = new NeverNonceStrategy();
+        assertFalse(strategy.requiresNonce("any-client"));
+        assertFalse(strategy.requiresNonce("any-client"));
+        assertEquals(strategy.getName(), "never");
+    }
+
+    @Test
+    public void neverStrategyShouldNeverRotate() {
+        NeverNonceStrategy strategy = new NeverNonceStrategy();
+        assertFalse(strategy.shouldRotate("any-client"));
+        assertFalse(strategy.shouldRotate("any-client"));
+    }
+
+    @Test
+    public void alwaysStrategyShouldAlwaysRequireNonce() {
+        AlwaysNonceStrategy strategy = new AlwaysNonceStrategy();
+        assertTrue(strategy.requiresNonce("client-1"));
+        assertTrue(strategy.requiresNonce("client-2"));
+        assertEquals(strategy.getName(), "always");
+    }
+
+    @Test
+    public void alwaysStrategyShouldNeverRotate() {
+        // AlwaysNonceStrategy reuses nonce until TTL expiry — no proactive rotation needed.
+        AlwaysNonceStrategy strategy = new AlwaysNonceStrategy();
+        assertFalse(strategy.shouldRotate("client-1"));
+        assertFalse(strategy.shouldRotate("client-1"));
+    }
+
+    @Test
+    public void rotatingStrategyShouldAlwaysRequireNonce() {
+        // requiresNonce is pure/side-effect-free — always true regardless of call count.
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3);
+        String client = "client-x";
+        assertTrue(strategy.requiresNonce(client));
+        assertTrue(strategy.requiresNonce(client));
+        assertTrue(strategy.requiresNonce(client));
+        assertTrue(strategy.requiresNonce(client));
+        assertEquals(strategy.getName(), "rotating");
+    }
+
+    @Test
+    public void rotatingStrategyShouldRotateAtModuloIntervals() {
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(3);
+        String client = "client-y";
+
+        assertFalse(strategy.shouldRotate(client)); // count=1
+        assertFalse(strategy.shouldRotate(client)); // count=2
+        assertTrue(strategy.shouldRotate(client));  // count=3 → 3%3==0
+        assertFalse(strategy.shouldRotate(client)); // count=4
+        assertFalse(strategy.shouldRotate(client)); // count=5
+        assertTrue(strategy.shouldRotate(client));  // count=6 → 6%3==0
+    }
+
+    @Test
+    public void rotatingStrategyShouldFloorRotateAfterUsesAtOne() {
+        // A misconfiguration of 0 or negative must not cause a div-by-zero in the strategy.
+        RotatingNonceStrategy strategy = new RotatingNonceStrategy(0);
+        // rotateAfterUses is floored to 1 — every validated proof triggers rotation
+        assertTrue(strategy.shouldRotate("c")); // count=1 → 1%1==0
+        assertTrue(strategy.shouldRotate("c")); // count=2 → 2%1==0
+        assertTrue(strategy.shouldRotate("c")); // count=3 → 3%1==0
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/proof/DPoPProofValidatorTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/proof/DPoPProofValidatorTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.proof;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.DPOP_JWT_TYPE;
+import static com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants.SHA256_HASH_ALG;
+import static com.wso2.openbanking.accelerator.gateway.util.GatewayConstants.GET_HTTP_METHOD;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+/**
+ * Unit tests for {@link DPoPProofValidator}. Exercises each RFC 9449 §4.3
+ * validation rule independently with both valid and invalid inputs.
+ */
+public class DPoPProofValidatorTest {
+
+    private static final Set<String> ACCEPTED_ALGS = new HashSet<>(Arrays.asList("ES256", "PS256"));
+    private static final long IAT_SKEW_SECONDS = 60L;
+    private static final String HTU = "https://api.example.com/resource";
+
+    private DPoPProofValidator validator;
+    private ECKey ecKey;
+    private String accessToken;
+    private String correctAth;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        validator = new DPoPProofValidator(ACCEPTED_ALGS, IAT_SKEW_SECONDS);
+        ecKey = new ECKeyGenerator(Curve.P_256).generate();
+        accessToken = "test.access.token";
+        correctAth = computeAth(accessToken);
+    }
+
+    @Test
+    public void validProofShouldSucceed() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        DPoPProofValidator.ValidationResult result = validator.validate(parsed, GET_HTTP_METHOD,
+                HTU, accessToken, null);
+        assertNotNull(result.getProofJkt());
+        assertNotNull(result.getJti());
+    }
+
+    @Test
+    public void validProofWithNonceShouldSucceed() throws Exception {
+        String nonce = "server-issued-nonce-123";
+        String proof = buildProof(ecKey, "POST", "https://api.example.com/data",
+                new Date(), UUID.randomUUID().toString(), correctAth, nonce);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        DPoPProofValidator.ValidationResult result = validator.validate(parsed, "POST",
+                "https://api.example.com/data", accessToken, nonce);
+        assertNotNull(result.getProofJkt());
+    }
+
+    @Test
+    public void missingProofShouldFail() {
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.parseDPoPProof(null));
+    }
+
+    @Test
+    public void wrongTypShouldFail() throws Exception {
+        ECKey key = new ECKeyGenerator(Curve.P_256).generate();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(new JOSEObjectType("JWT"))
+                .jwk(key.toPublicJWK())
+                .build();
+        String proof = signProof(key, header,
+                buildBasicClaims(GET_HTTP_METHOD, "https://example.com", new Date(),
+                        UUID.randomUUID().toString(), correctAth, null));
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, "https://example.com", accessToken, null));
+    }
+
+    @Test
+    public void unparseableProofShouldFail() {
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.parseDPoPProof("notajwt"));
+    }
+
+    @Test
+    public void unknownAlgorithmShouldFail() throws Exception {
+        RSAKey rsaKey = new RSAKeyGenerator(2048).generate();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .type(new JOSEObjectType(DPOP_JWT_TYPE))
+                .jwk(rsaKey.toPublicJWK())
+                .build();
+        JWTClaimsSet claims = buildBasicClaims(GET_HTTP_METHOD, "https://example.com",
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new RSASSASigner(rsaKey));
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(jwt.serialize());
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, "https://example.com", accessToken, null));
+    }
+
+    @Test
+    public void wrongHtmShouldFail() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, "POST", HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void wrongHtuShouldFail() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, "https://api.example.com/other",
+                        accessToken, null));
+    }
+
+    @Test
+    public void expiredIatShouldFail() throws Exception {
+        Date expiredIat = new Date(System.currentTimeMillis() - (IAT_SKEW_SECONDS + 5) * 1000L);
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                expiredIat, UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void futureIatBeyondSkewShouldFail() throws Exception {
+        Date futureIat = new Date(System.currentTimeMillis() + (IAT_SKEW_SECONDS + 5) * 1000L);
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                futureIat, UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void wrongAthShouldFail() throws Exception {
+        String wrongAth = computeAth("different.access.token");
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), wrongAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void missingAthWhenTokenPresentShouldFail() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), null, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, null));
+    }
+
+    @Test
+    public void wrongNonceShouldReturnUseNonceError() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, "wrong-nonce");
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, "correct-nonce"));
+    }
+
+    @Test
+    public void missingNonceWhenRequiredShouldReturnUseNonceError() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                () -> validator.validate(parsed, GET_HTTP_METHOD, HTU,
+                        accessToken, "required-nonce"));
+    }
+
+    @Test
+    public void htuTrailingSlashShouldBeNormalized() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, "https://api.example.com/resource/",
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        DPoPProofValidator.ValidationResult result = validator.validate(parsed, GET_HTTP_METHOD,
+                HTU, accessToken, null);
+        assertNotNull(result.getProofJkt());
+    }
+
+    @Test
+    public void proofWithNullHtuShouldFail() throws Exception {
+        // Passing null as htu omits the claim, triggering the null branch in normalizedUriEquals
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, null,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD,
+                        HTU, accessToken, null));
+    }
+
+    @Test
+    public void proofWithMissingJtiShouldFail() throws Exception {
+        // Pass null jti so the jti claim is absent from the proof
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), null, correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertErrorCode(DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                () -> validator.validate(parsed, GET_HTTP_METHOD,
+                        HTU, accessToken, null));
+    }
+
+    @Test
+    public void parseDPoPProofShouldPopulateKidWhenJwkHasKid() throws Exception {
+        ECKey keyWithKid = new ECKeyGenerator(Curve.P_256).keyID("my-key-id").generate();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(new JOSEObjectType(DPOP_JWT_TYPE))
+                .jwk(keyWithKid.toPublicJWK())
+                .build();
+        JWTClaimsSet claims = buildBasicClaims(GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(keyWithKid));
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(jwt.serialize());
+        assertEquals(parsed.getKid(), "my-key-id");
+    }
+
+    @Test
+    public void parseDPoPProofShouldReturnNullKidWhenJwkHasNoKid() throws Exception {
+        // ecKey (from setUp) was generated without a kid
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        org.testng.Assert.assertNull(parsed.getKid());
+    }
+
+    @Test
+    public void parsedProofShouldHaveNonNullJwkThumbprint() throws Exception {
+        String proof = buildProof(ecKey, GET_HTTP_METHOD, HTU,
+                new Date(), UUID.randomUUID().toString(), correctAth, null);
+
+        DPoPProofValidator.ParsedProof parsed = validator.parseDPoPProof(proof);
+        assertNotNull(parsed.getJwkThumbprint(),
+                "JWK thumbprint must be computed during parseDPoPProof");
+    }
+
+    private String buildProof(ECKey key, String htm, String htu, Date iat,
+                              String jti, String ath, String nonce) throws Exception {
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .type(new JOSEObjectType(DPOP_JWT_TYPE))
+                .jwk(key.toPublicJWK())
+                .build();
+        return signProof(key, header, buildBasicClaims(htm, htu, iat, jti, ath, nonce));
+    }
+
+    private JWTClaimsSet buildBasicClaims(String htm, String htu, Date iat,
+                                          String jti, String ath, String nonce) {
+        JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+                .jwtID(jti)
+                .claim(DPoPConstants.Claims.HTM_CLAIM, htm)
+                .claim(DPoPConstants.Claims.HTU_CLAIM, htu)
+                .issueTime(iat);
+        if (ath != null) {
+            builder.claim(DPoPConstants.Claims.ATH_CLAIM, ath);
+        }
+        if (nonce != null) {
+            builder.claim(DPoPConstants.Claims.NONCE_CLAIM, nonce);
+        }
+        return builder.build();
+    }
+
+    private String signProof(ECKey key, JWSHeader header, JWTClaimsSet claims) throws Exception {
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(key));
+        return jwt.serialize();
+    }
+
+    private String computeAth(String token) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance(SHA256_HASH_ALG);
+        byte[] hash = digest.digest(token.getBytes(StandardCharsets.US_ASCII));
+        return Base64URL.encode(hash).toString();
+    }
+
+    private void assertErrorCode(DPoPProofException.ErrorCode expected, ValidatorCall call) {
+        try {
+            call.execute();
+            fail("Expected DPoPProofException with error code " + expected);
+        } catch (DPoPProofException e) {
+            assertEquals(e.getErrorCode(), expected);
+        } catch (Exception e) {
+            fail("Unexpected exception type: " + e.getClass().getName() + ": " + e.getMessage());
+        }
+    }
+
+    @FunctionalInterface
+    interface ValidatorCall {
+        void execute() throws Exception;
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/util/ChallengeTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/util/ChallengeTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.util;
+
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
+import org.apache.axis2.context.MessageContext;
+import org.apache.http.HttpHeaders;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.core.axis2.Axis2Sender;
+import org.apache.synapse.transport.passthru.util.RelayUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link Challenge}. Mocks static {@link RelayUtils} and
+ * {@link Axis2Sender} entry points to avoid real HTTP I/O.
+ */
+@PrepareForTest({RelayUtils.class, Axis2Sender.class})
+public class ChallengeTest extends PowerMockTestCase {
+
+    private static final String ACCEPTED_ALGS = "ES256 PS256";
+    private static final String HEADER_DPOP_NONCE = "DPoP-Nonce";
+
+    private Challenge challenge;
+    private Axis2MessageContext mockSynCtx;
+    private MessageContext mockAxis2MC;
+
+    @BeforeMethod
+    public void setUp() {
+        challenge = new Challenge(ACCEPTED_ALGS);
+        mockSynCtx = Mockito.mock(Axis2MessageContext.class);
+        mockAxis2MC = Mockito.mock(MessageContext.class);
+
+        Mockito.when(mockSynCtx.getAxis2MessageContext()).thenReturn(mockAxis2MC);
+
+        PowerMockito.mockStatic(RelayUtils.class);
+        PowerMockito.mockStatic(Axis2Sender.class);
+    }
+
+    @Test
+    public void send401WithInvalidDPoPProofShouldSetWwwAuthenticateHeader() {
+        challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                "Proof failed", null);
+
+        Map<String, String> headers = captureResponseHeaders();
+        String wwwAuth = headers.get(HttpHeaders.WWW_AUTHENTICATE);
+        assertNotNull(wwwAuth, "WWW-Authenticate header must be set");
+        assertTrue(wwwAuth.startsWith("DPoP"), "Challenge must start with 'DPoP'");
+        assertTrue(wwwAuth.contains("error=\"invalid_dpop_proof\""),
+                "Challenge must contain the RFC error code");
+        assertFalse(headers.containsKey(HEADER_DPOP_NONCE),
+                "DPoP-Nonce header must not be present when no nonce is supplied");
+    }
+
+    @Test
+    public void send401WithUseDPoPNonceShouldSetDPoPNonceHeader() {
+        String nonce = "server-issued-nonce-abc";
+
+        challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.USE_DPOP_NONCE,
+                "Nonce required", nonce);
+
+        Map<String, String> headers = captureResponseHeaders();
+        String dpopNonce = headers.get(HEADER_DPOP_NONCE);
+        assertNotNull(dpopNonce, "DPoP-Nonce header must be set when a nonce is supplied");
+        assertEquals(dpopNonce, nonce);
+
+        String wwwAuth = headers.get(HttpHeaders.WWW_AUTHENTICATE);
+        assertNotNull(wwwAuth);
+        assertTrue(wwwAuth.contains("error=\"use_dpop_nonce\""));
+    }
+
+    @Test
+    public void send401WithNullMessageShouldNotThrow() {
+        challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                null, null);
+
+        Map<String, String> headers = captureResponseHeaders();
+        String wwwAuth = headers.get(HttpHeaders.WWW_AUTHENTICATE);
+        assertNotNull(wwwAuth);
+        assertTrue(wwwAuth.contains("error=\"invalid_dpop_proof\""));
+        assertFalse(wwwAuth.contains("error_description"),
+                "No error_description should be present for null message");
+    }
+
+    @Test
+    public void send401ShouldDispatchResponseViaAxis2Sender() {
+        challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                "some error", null);
+
+        PowerMockito.verifyStatic();
+        Axis2Sender.sendBack(mockSynCtx);
+    }
+
+    @Test
+    public void send401ShouldNotEchoRequestHeadersInResponse() {
+        // Simulate what Synapse holds in TRANSPORT_HEADERS during handleRequest —
+        // the incoming client request headers.
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "DPoP <access-token>");
+        requestHeaders.put("DPoP", "<dpop-proof>");
+        requestHeaders.put("User-Agent", "PostmanRuntime/7.54.0");
+        requestHeaders.put("Host", "localhost:8243");
+        Mockito.when(mockAxis2MC.getProperty(MessageContext.TRANSPORT_HEADERS))
+                .thenReturn(requestHeaders);
+
+        challenge.send401(mockSynCtx, DPoPProofException.ErrorCode.INVALID_DPOP_PROOF,
+                "Proof failed", null);
+
+        Map<String, String> responseHeaders = captureResponseHeaders();
+        assertFalse(responseHeaders.containsKey("Authorization"),
+                "Authorization request header must not appear in 401 response");
+        assertFalse(responseHeaders.containsKey("DPoP"),
+                "DPoP request header must not appear in 401 response");
+        assertFalse(responseHeaders.containsKey("User-Agent"),
+                "User-Agent request header must not appear in 401 response");
+        assertFalse(responseHeaders.containsKey("Host"),
+                "Host request header must not appear in 401 response");
+        assertTrue(responseHeaders.containsKey(HttpHeaders.WWW_AUTHENTICATE),
+                "WWW-Authenticate must still be present");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> captureResponseHeaders() {
+        ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(mockAxis2MC)
+                .setProperty(Mockito.eq(MessageContext.TRANSPORT_HEADERS), captor.capture());
+        return (Map<String, String>) captor.getValue();
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/util/ChallengeTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/util/ChallengeTest.java
@@ -27,6 +27,7 @@ import org.apache.synapse.transport.passthru.util.RelayUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
@@ -45,6 +46,7 @@ import static org.testng.Assert.assertTrue;
  * {@link Axis2Sender} entry points to avoid real HTTP I/O.
  */
 @PrepareForTest({RelayUtils.class, Axis2Sender.class})
+@PowerMockIgnore({"jdk.internal.reflect.*", "javax.management.*"})
 public class ChallengeTest extends PowerMockTestCase {
 
     private static final String ACCEPTED_ALGS = "ES256 PS256";

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/util/DPoPUtilsTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/java/com/wso2/openbanking/accelerator/gateway/dpop/util/DPoPUtilsTest.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wso2.openbanking.accelerator.gateway.dpop.util;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.wso2.openbanking.accelerator.gateway.dpop.DPoPConstants;
+import com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofException;
+import org.apache.axis2.context.MessageContext;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.transport.nhttp.NhttpConstants;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Unit tests for {@link DPoPUtils} pure helpers and Synapse-context-dependent methods.
+ */
+public class DPoPUtilsTest {
+
+    private Axis2MessageContext mockSynCtx;
+    private MessageContext mockAxis2MC;
+
+    @BeforeMethod
+    public void setUp() {
+        mockSynCtx = Mockito.mock(Axis2MessageContext.class);
+        mockAxis2MC = Mockito.mock(MessageContext.class);
+        Mockito.when(mockSynCtx.getAxis2MessageContext()).thenReturn(mockAxis2MC);
+    }
+
+    @Test
+    public void parseBoolNullShouldReturnDefault() {
+        assertTrue(DPoPUtils.parseBool(null, true));
+        assertFalse(DPoPUtils.parseBool(null, false));
+    }
+
+    @Test
+    public void parseBoolLowercaseTrueShouldReturnTrue() {
+        assertTrue(DPoPUtils.parseBool("true", false));
+    }
+
+    @Test
+    public void parseBoolUppercaseTrueShouldReturnTrue() {
+        assertTrue(DPoPUtils.parseBool("TRUE", false));
+    }
+
+    @Test
+    public void parseBoolFalseShouldReturnFalse() {
+        assertFalse(DPoPUtils.parseBool("false", true));
+    }
+
+    @Test
+    public void parseBoolInvalidStringShouldReturnFalse() {
+        assertFalse(DPoPUtils.parseBool("invalid", false));
+        assertFalse(DPoPUtils.parseBool("yes", false));
+    }
+
+    @Test
+    public void parseLongNullShouldReturnDefault() {
+        assertEquals(DPoPUtils.parseLong(null, 42L), 42L);
+    }
+
+    @Test
+    public void parseLongValidNumberShouldReturnParsed() {
+        assertEquals(DPoPUtils.parseLong("120", 0L), 120L);
+    }
+
+    @Test
+    public void parseLongWhitespaceTrimmingNumber() {
+        assertEquals(DPoPUtils.parseLong("  300  ", 0L), 300L);
+    }
+
+    @Test
+    public void parseLongInvalidStringShouldReturnDefault() {
+        assertEquals(DPoPUtils.parseLong("abc", 99L), 99L);
+    }
+
+    @Test
+    public void parseStringNullShouldReturnDefault() {
+        assertEquals(DPoPUtils.parseString(null, "default"), "default");
+    }
+
+    @Test
+    public void parseStringBlankShouldReturnDefault() {
+        assertEquals(DPoPUtils.parseString("   ", "default"), "default");
+    }
+
+    @Test
+    public void parseStringValueShouldBeTrimmed() {
+        assertEquals(DPoPUtils.parseString("  value  ", "default"), "value");
+    }
+
+    @Test
+    public void parseAlgorithmsNullShouldReturnDefaultContainingES256() {
+        Set<String> algs = DPoPUtils.parseAlgorithms(null);
+        assertNotNull(algs);
+        assertTrue(algs.contains("ES256"), "Default algorithm set should contain ES256");
+    }
+
+    @Test
+    public void parseAlgorithmsBlankShouldReturnDefaultContainingES256() {
+        Set<String> algs = DPoPUtils.parseAlgorithms("  ");
+        assertTrue(algs.contains("ES256"));
+    }
+
+    @Test
+    public void parseAlgorithmsCommaSeparatedShouldReturnSetOfTwo() {
+        Set<String> algs = DPoPUtils.parseAlgorithms("ES256,PS256");
+        assertEquals(algs.size(), 2);
+        assertTrue(algs.contains("ES256"));
+        assertTrue(algs.contains("PS256"));
+    }
+
+    @Test
+    public void extractTokenNullHeaderShouldReturnNull() {
+        assertNull(DPoPUtils.extractToken(null, "Bearer"));
+    }
+
+    @Test
+    public void extractTokenBearerHeaderShouldReturnToken() {
+        assertEquals(DPoPUtils.extractToken("Bearer abc123", "Bearer"), "abc123");
+    }
+
+    @Test
+    public void extractTokenDPoPSchemeShouldReturnToken() {
+        assertEquals(DPoPUtils.extractToken("DPoP mytoken", "DPoP"), "mytoken");
+    }
+
+    @Test
+    public void extractTokenCaseInsensitiveSchemeShouldWork() {
+        assertEquals(DPoPUtils.extractToken("BEARER mytoken", "Bearer"), "mytoken");
+    }
+
+    @Test
+    public void extractTokenWrongSchemeShouldReturnNull() {
+        assertNull(DPoPUtils.extractToken("Basic dXNlcjpwYXNz", "Bearer"));
+    }
+
+    @Test
+    public void removeHeaderShouldRemoveExactMatch() {
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        headers.put("Authorization", "Bearer token");
+        DPoPUtils.removeHeader(headers, "Authorization");
+        assertFalse(headers.containsKey("Authorization"));
+    }
+
+    @Test
+    public void removeHeaderShouldRemoveCaseVariants() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("authorization", "Bearer token1");
+        headers.put("AUTHORIZATION", "Bearer token2");
+        DPoPUtils.removeHeader(headers, "Authorization");
+        assertFalse(headers.containsKey("authorization"));
+        assertFalse(headers.containsKey("AUTHORIZATION"));
+    }
+
+    @Test
+    public void isJwtTokenNullShouldReturnFalse() {
+        assertFalse(DPoPUtils.isJwtToken(null));
+    }
+
+    @Test
+    public void isJwtTokenBlankShouldReturnFalse() {
+        assertFalse(DPoPUtils.isJwtToken(""));
+        assertFalse(DPoPUtils.isJwtToken("   "));
+    }
+
+    @Test
+    public void isJwtTokenThreePartShouldReturnTrue() {
+        assertTrue(DPoPUtils.isJwtToken("a.b.c"));
+    }
+
+    @Test
+    public void isJwtTokenTwoPartShouldReturnFalse() {
+        assertFalse(DPoPUtils.isJwtToken("a.b"));
+    }
+
+    @Test
+    public void isJwtTokenFourPartShouldReturnFalse() {
+        assertFalse(DPoPUtils.isJwtToken("a.b.c.d"));
+    }
+
+    @Test
+    public void extractJktFromJwtShouldReturnJktWhenPresent() throws Exception {
+        ECKey key = new ECKeyGenerator(Curve.P_256).generate();
+        String jkt = "expected-jkt-value";
+
+        Map<String, Object> cnf = new HashMap<>();
+        cnf.put(DPoPConstants.Claims.JKT_CLAIM, jkt);
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .claim(DPoPConstants.Claims.CNF_CLAIM, cnf)
+                .subject("client")
+                .build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(key));
+
+        String result = DPoPUtils.extractJktFromJwt(jwt.serialize());
+        assertEquals(result, jkt);
+    }
+
+    @Test
+    public void extractJktFromJwtWithoutCnfShouldReturnNull() throws Exception {
+        ECKey key = new ECKeyGenerator(Curve.P_256).generate();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder().subject("client").build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(key));
+
+        String result = DPoPUtils.extractJktFromJwt(jwt.serialize());
+        assertNull(result);
+    }
+
+    @Test
+    public void extractJktFromJwtNotAJwtShouldThrowDPoPProofException() {
+        try {
+            DPoPUtils.extractJktFromJwt("not.a.jwt");
+            fail("Expected DPoPProofException");
+        } catch (DPoPProofException e) {
+            assertEquals(e.getErrorCode(), DPoPProofException.ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    @Test
+    public void checkHttpsForHttpsUrlShouldNotThrow() throws DPoPProofException {
+        DPoPUtils.checkHttps("https://api.example.com/resource");
+    }
+
+    @Test
+    public void checkHttpsForHttpUrlShouldThrow() {
+        try {
+            DPoPUtils.checkHttps("http://api.example.com/resource");
+            fail("Expected DPoPProofException");
+        } catch (DPoPProofException e) {
+            assertEquals(e.getErrorCode(), DPoPProofException.ErrorCode.INVALID_DPOP_PROOF);
+        }
+    }
+
+    @Test
+    public void checkHttpsForNullShouldNotThrow() throws DPoPProofException {
+        DPoPUtils.checkHttps(null);
+    }
+
+    @Test
+    public void getTransportHeadersShouldReturnCaseInsensitiveMap() {
+        Map<String, String> rawHeaders = new HashMap<>();
+        rawHeaders.put("Authorization", "Bearer token");
+        rawHeaders.put("dpop", "proof-value");
+        Mockito.when(mockAxis2MC.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(rawHeaders);
+
+        Map<String, String> result = DPoPUtils.getTransportHeaders(mockSynCtx);
+
+        assertNotNull(result);
+        assertEquals(result.get("authorization"), "Bearer token");
+        assertEquals(result.get("AUTHORIZATION"), "Bearer token");
+        assertEquals(result.get("DPoP"), "proof-value");
+    }
+
+    @Test
+    public void getTransportHeadersNullPropertyShouldReturnEmptyMap() {
+        Mockito.when(mockAxis2MC.getProperty(MessageContext.TRANSPORT_HEADERS)).thenReturn(null);
+
+        Map<String, String> result = DPoPUtils.getTransportHeaders(mockSynCtx);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void normalizeHtuShouldBuildCorrectUri() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Host", "api.example.com");
+
+        Mockito.when(mockSynCtx.getProperty("TRANSPORT_IN_NAME")).thenReturn("https");
+        Mockito.when(mockSynCtx.getProperty("REST_FULL_REQUEST_PATH")).thenReturn("/resource");
+
+        String htu = DPoPUtils.normalizeHtu(mockSynCtx, headers);
+
+        assertEquals(htu, "https://api.example.com/resource");
+    }
+
+    @Test
+    public void hasMultipleDPopHeadersShouldReturnTrueWhenExcessContainsDPoP() {
+        Map<String, String> excessHeaders = new HashMap<>();
+        excessHeaders.put("DPoP", "second-proof-value");
+        Mockito.when(mockAxis2MC.getProperty(NhttpConstants.EXCESS_TRANSPORT_HEADERS))
+                .thenReturn(excessHeaders);
+
+        assertTrue(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx));
+    }
+
+    @Test
+    public void hasMultipleDPopHeadersShouldReturnFalseWhenExcessEmpty() {
+        Mockito.when(mockAxis2MC.getProperty(NhttpConstants.EXCESS_TRANSPORT_HEADERS))
+                .thenReturn(new HashMap<>());
+
+        assertFalse(DPoPUtils.hasMultipleDPopHeaders(mockSynCtx));
+    }
+}

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/resources/testng.xml
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/src/test/resources/testng.xml
@@ -73,4 +73,16 @@
             <class name="com.wso2.openbanking.accelerator.gateway.handler.JwsResponseSignatureHandlerTest"/>
         </classes>
     </test>
+    <test name="dpop-tests">
+        <classes>
+            <class name="com.wso2.openbanking.accelerator.gateway.dpop.binding.AccessTokenBinderTest"/>
+            <class name="com.wso2.openbanking.accelerator.gateway.dpop.binding.IntrospectionClientTest"/>
+            <class name="com.wso2.openbanking.accelerator.gateway.dpop.cache.LocalDPoPCacheProviderTest"/>
+            <class name="com.wso2.openbanking.accelerator.gateway.dpop.nonce.NonceStrategyTest"/>
+            <class name="com.wso2.openbanking.accelerator.gateway.dpop.proof.DPoPProofValidatorTest"/>
+            <class name="com.wso2.openbanking.accelerator.gateway.dpop.util.ChallengeTest"/>
+            <class name="com.wso2.openbanking.accelerator.gateway.dpop.util.DPoPUtilsTest"/>
+            <class name="com.wso2.openbanking.accelerator.gateway.dpop.DPoPHandlerTest"/>
+        </classes>
+    </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -666,6 +666,11 @@
                 <version>${org.wso2.carbon.apimgt.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.apimgt</groupId>
+                <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
+                <version>${org.wso2.carbon.apimgt.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt</artifactId>
                 <version>${jjwt.version}</version>


### PR DESCRIPTION
## Purpose
Adds a full DPoP (Demonstrating Proof of Possession, RFC 9449) implementation to the Financial Services Accelerator gateway module. The `DPoPHandler` is a Synapse handler that validates DPoP-bound access tokens and their proof JWTs before they reach the downstream OAuth authenticator, enabling FAPI 2.0 compliant deployments.

**Issue link:** https://github.com/wso2/financial-services-accelerator/issues/953

**Doc Issue:** N/A

**Applicable Labels:** feature, gateway, security, fapi2.0, 3.0.0

------

### Changes

**`com.wso2.openbanking.accelerator.gateway`**
- `DPoPHandler` — Synapse handler that validates DPoP proofs per RFC 9449 §4.3 (signature, algorithm, `typ`, `htm`, `htu`, `iat`, `ath`, `jti`). Rewrites `Authorization: DPoP` to `Authorization: Bearer` after successful validation. DPoP enforcement is **opt-in per API** via a handler property (`apiDPoPEnabled=true`).
- `DPoPProofValidator` — Pure JOSE proof validation; parses proof JWTs once per request and exposes `ParsedProof` / `ValidationResult` value objects.
- `AccessTokenBinder` — Resolves `cnf.jkt` from JWT or opaque access tokens and verifies the binding against the proof's JWK thumbprint.
- `IntrospectionClient` — Wraps the APIM Key Manager introspection endpoint with an in-memory result cache to avoid repeated round-trips for the same token.
- `DPoPCacheProvider` SPI + `LocalDPoPCacheProvider` — JTI replay-defense set and nonce store backed by the Carbon cache infrastructure. Distributed deployments can plug in a custom implementation via `CacheProviderClass`.
- `AlwaysNonceStrategy`, `NeverNonceStrategy`, `RotatingNonceStrategy` — Three built-in nonce enforcement policies configurable via `open-banking.xml`. Nonce lifecycle is fully RFC 9449 §11.3 compliant — a server-issued nonce is required on every subsequent proof once one has been delivered to the client, even between rotation points.
- `Challenge` — Builds the RFC 9449 §7.1 `WWW-Authenticate: DPoP` challenge and sends the 401 response.

**`com.wso2.openbanking.accelerator.common`**
- `OpenBankingBaseCache` — Added atomic `addToCacheIfAbsent` and `removeFromCacheIfMatch` operations (JSR-107 `putIfAbsent` / `remove(k,v)`) required for race-free JTI replay detection.

**Configuration**
- `open-banking.xml.j2` — New `<Gateway><DPoP>` section with all configurable knobs: `AcceptedAlgorithms`, `IatSkewSeconds`, `JtiCacheTtlSeconds`, `NonceStrategy`, `NonceTtlSeconds`, `HttpsRequired`, `StripDpopHeader`, `IntrospectionCacheTtlSeconds`, `CacheProviderClass`.

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable). — N/A (new feature)
8. [x] Have you followed secure coding standards in WSO2 Secure Engineering Guidelines?

### Testing Checklist

1. [x] Written unit tests. — New test classes covering `DPoPHandler`, `DPoPProofValidator`, `AccessTokenBinder`, `IntrospectionClient`, `LocalDPoPCacheProvider`, `Challenge`, `DPoPUtils`, and all nonce strategies.
2. [ ] Verified tests in multiple database environments (if applicable). — N/A
3. [ ] Tested with BI enabled (if applicable). — N/A