### PR TITLE
Remove default admin credential fallback and fail loudly on missing Consent API credentials

### DIFF
--- a/open-banking-accelerator/accelerators/ob-apim/carbon-home/repository/resources/conf/templates/repository/conf/open-banking.xml.j2
+++ b/open-banking-accelerator/accelerators/ob-apim/carbon-home/repository/resources/conf/templates/repository/conf/open-banking.xml.j2
@@ -374,14 +374,10 @@
         <!-- Administrator username to login to the SI server for data publishing. -->
     {% if open_banking.data_publishing.username is defined %}
         <Username>{{open_banking.data_publishing.username}}</Username>
-    {% else %}
-        <Username>admin@wso2.com@carbon.super</Username>
     {% endif %}
         <!-- Administrator password to login to the SI server for data publishing. -->
     {% if open_banking.data_publishing.password is defined %}
         <Password>{{open_banking.data_publishing.password}}</Password>
-    {% else %}
-        <Password>wso2123</Password>
     {% endif %}
         <!-- Server URL of the remote SI server used to collect statistics. Must
         be specified in {protocol://hostname:port/} format. -->

--- a/open-banking-accelerator/accelerators/ob-is/carbon-home/repository/resources/conf/templates/repository/conf/open-banking.xml.j2
+++ b/open-banking-accelerator/accelerators/ob-is/carbon-home/repository/resources/conf/templates/repository/conf/open-banking.xml.j2
@@ -418,13 +418,9 @@
         <ConsentAPICredentials>
             {% if open_banking.consent.api_credentials.username is defined %}
                 <Username>{{open_banking.consent.api_credentials.username}}</Username>
-            {% else %}
-                <Username>admin@wso2.com</Username>
             {% endif %}
             {% if open_banking.consent.api_credentials.password is defined %}
                 <Password>{{open_banking.consent.api_credentials.password}}</Password>
-            {% else %}
-                <Password>wso2123</Password>
             {% endif %}
         </ConsentAPICredentials>
         <Portal>
@@ -927,14 +923,10 @@
         <!-- Administrator username to login to the SI server for data publishing. -->
     {% if open_banking.data_publishing.username is defined %}
         <Username>{{open_banking.data_publishing.username}}</Username>
-    {% else %}
-        <Username>admin@wso2.com@carbon.super</Username>
     {% endif %}
         <!-- Administrator password to login to the SI server for data publishing. -->
     {% if open_banking.data_publishing.password is defined %}
         <Password>{{open_banking.data_publishing.password}}</Password>
-    {% else %}
-        <Password>wso2123</Password>
     {% endif %}
         <!-- Server URL of the remote SI server used to collect statistics. Must
         be specified in {protocol://hostname:port/} format. -->

--- a/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.authentication.webapp/src/main/java/com/wso2/openbanking/accelerator/authentication/webapp/OBConsentConfirmServlet.java
+++ b/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.authentication.webapp/src/main/java/com/wso2/openbanking/accelerator/authentication/webapp/OBConsentConfirmServlet.java
@@ -19,6 +19,7 @@
 package com.wso2.openbanking.accelerator.authentication.webapp;
 
 import com.wso2.openbanking.accelerator.common.config.OpenBankingConfigParser;
+import com.wso2.openbanking.accelerator.common.exception.OpenBankingRuntimeException;
 import com.wso2.openbanking.accelerator.common.util.Generated;
 import com.wso2.openbanking.accelerator.consent.extensions.authservlet.model.OBAuthServletInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -136,6 +137,10 @@ public class OBConsentConfirmServlet extends HttpServlet {
             }
         } catch (IOException e) {
             log.error("Exception while calling persistence endpoint", e);
+            return null;
+        } catch (OpenBankingRuntimeException e) {
+            log.error("Unable to persist consent data due to a server configuration error: " +
+                    e.getErrorCode(), e);
             return null;
         }
     }

--- a/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.authentication.webapp/src/main/java/com/wso2/openbanking/accelerator/authentication/webapp/OBConsentServlet.java
+++ b/open-banking-accelerator/internal-apis/internal-webapps/com.wso2.openbanking.authentication.webapp/src/main/java/com/wso2/openbanking/accelerator/authentication/webapp/OBConsentServlet.java
@@ -20,6 +20,7 @@ package com.wso2.openbanking.accelerator.authentication.webapp;
 
 import com.wso2.openbanking.accelerator.authentication.webapp.util.Constants;
 import com.wso2.openbanking.accelerator.common.config.OpenBankingConfigParser;
+import com.wso2.openbanking.accelerator.common.exception.OpenBankingRuntimeException;
 import com.wso2.openbanking.accelerator.common.util.Generated;
 import com.wso2.openbanking.accelerator.consent.extensions.authservlet.impl.ConsentMgrAuthServletImpl;
 import com.wso2.openbanking.accelerator.consent.extensions.authservlet.impl.ISDefaultAuthServletImpl;
@@ -86,8 +87,18 @@ public class OBConsentServlet extends HttpServlet {
 
         // get consent data
         String sessionDataKey = request.getParameter("sessionDataKeyConsent");
-        HttpResponse consentDataResponse = getConsentDataWithKey(sessionDataKey, getServletContext());
         JSONObject dataSet = new JSONObject();
+        HttpResponse consentDataResponse;
+        try {
+            consentDataResponse = getConsentDataWithKey(sessionDataKey, getServletContext());
+        } catch (OpenBankingRuntimeException e) {
+            log.error("Unable to retrieve consent data due to a server configuration error: " +
+                    e.getErrorCode(), e);
+            request.getSession().invalidate();
+            response.sendRedirect("retry.do?status=Error&statusMsg=Consent retrieval failed due to a server " +
+                    "configuration error. Please contact the administrator.");
+            return;
+        }
         log.debug("HTTP response for consent retrieval" + consentDataResponse.toString());
         try {
             if (consentDataResponse.getStatusLine().getStatusCode() == HttpURLConnection.HTTP_MOVED_TEMP &&
@@ -283,6 +294,11 @@ public class OBConsentServlet extends HttpServlet {
                     .get(Constants.USERNAME_IN_OB_CONFIGS);
             password = (String) OpenBankingConfigParser.getInstance().getConfiguration()
                     .get(Constants.PASSWORD_IN_OB_CONFIGS);
+        }
+
+        if (StringUtils.isBlank(username) || StringUtils.isBlank(password)) {
+            log.error("Username or Password is missing for <ConsentAPICredentials> configuration.");
+            throw new OpenBankingRuntimeException("Consent API credentials are not configured on the server.");
         }
         return Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
## Remove default admin credential fallback and fail loudly on missing Consent API credentials

- Removes the hardcoded `admin@wso2.com / wso2123` fallback for ConsentAPICredentials and data-publishing username/password in `open-banking.xml.j2` (ob-is and ob-apim), closing the silent-default-credentials security gap.

- Fixes `OBConsentServlet.getConsentApiCredentials()` to validate the resolved username/password and throw `OpenBankingRuntimeException` with a clear log instead of silently building a null:null Basic Auth header.

- Handles this at both call sites (`OBConsentServlet#doGet`, `OBConsentConfirmServlet#persistConsentData`): logs the failure server-side and redirects to a safe, generic retry.do error instead of leaking the misleading downstream IS auth-failure message to the user.

**Public Issue:** 
- https://github.com/wso2/financial-services-accelerator/issues/969

**Related PRs:**
- https://github.com/wso2-support/financial-open-banking/pull/3488

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
