### PR TITLE
fix(DPoP): Exclude Java 8-incompatible transitive dependencies from gateway module

### DIFF
--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/pom.xml
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.gateway/pom.xml
@@ -46,6 +46,12 @@
         <dependency>
             <groupId>com.wso2.openbanking.accelerator</groupId>
             <artifactId>com.wso2.openbanking.accelerator.common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.carbon.identity.framework</groupId>
+                    <artifactId>org.wso2.carbon.identity.testutil</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.synapse</groupId>
@@ -116,6 +122,16 @@
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.gateway</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.bsf.wso2</groupId>
+                    <artifactId>bsf-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.openjdk.nashorn</groupId>
+                    <artifactId>nashorn-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>


### PR DESCRIPTION
## Summary

Adding `org.wso2.carbon.apimgt.gateway` as a dependency for DPoP support transitively pulled in several Java 11-only artifacts via `synapse-extensions`, breaking builds on Java 8:

- **`org.apache.bsf.wso2:bsf-all`** — declares `SleepScriptEngineFactory` in its service file but doesn't bundle the class, causing `ScriptEngineManager` warnings at test startup.
- **`org.openjdk.nashorn:nashorn-core:15.4`** — compiled with class file version 55.0 (Java 11), which Java 8 cannot load (max 52.0). This crashed test class instantiation with `TestOBExtensionImpl`.
- **`org.wso2.carbon.identity.testutil`** (via `accelerator.common` → `identity.oauth` → `identity.event`) — declares `CarbonBasedTestListener` as a TestNG listener service, but it requires Carbon test infrastructure that isn't present in this environment, causing TestNG to abort the forked process.

## Fix

Added exclusions on the relevant dependencies in `com.wso2.openbanking.accelerator.gateway/pom.xml`:
- Excluded `bsf-all` and `nashorn-core` from `org.wso2.carbon.apimgt.gateway` (both come via `synapse-extensions`).
- Excluded `org.wso2.carbon.identity.testutil` from `com.wso2.openbanking.accelerator.common`.

Java 8 provides Nashorn built-in, so excluding the standalone `nashorn-core` jar is safe.

## Test plan

- [ ] Build passes on Java 8 (`mvn clean install`)
- [ ] Build passes on Java 11 (`mvn clean install`)
- [ ] DPoP gateway tests execute without `SurefireBooterForkException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)