### PR TITLE
[OB3] Fix misleading invalid_request error for deleted OAuth clients during token issuance

### DIFF
--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/token/TokenFilter.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/token/TokenFilter.java
@@ -32,6 +32,7 @@ import com.wso2.openbanking.accelerator.identity.util.IdentityCommonUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -115,7 +116,13 @@ public class TokenFilter implements Filter {
         } catch (CertificateEncodingException e) {
             throw new ServletException("Certificate not valid", e);
         } catch (OpenBankingException e) {
-            if (e.getMessage().contains("Error occurred while retrieving OAuth2 application data")) {
+            if (e.getCause() instanceof InvalidOAuthClientException) {
+                // The client_id does not correspond to an existing OAuth application (e.g. it was deleted) -
+                // surface the standard OAuth2 invalid_client error instead of a generic metadata-retrieval one.
+                getDefaultTokenFilter().handleValidationFailure((HttpServletResponse) response,
+                        HttpServletResponse.SC_UNAUTHORIZED, IdentityCommonConstants.OAUTH2_INVALID_CLIENT_MESSAGE,
+                        "A valid OAuth client could not be found for client_id: " + clientId);
+            } else if (e.getMessage().contains("Error occurred while retrieving OAuth2 application data")) {
                 getDefaultTokenFilter().handleValidationFailure((HttpServletResponse) response,
                         HttpServletResponse.SC_INTERNAL_SERVER_ERROR, IdentityCommonConstants
                                 .OAUTH2_INTERNAL_SERVER_ERROR, "OAuth2 application data retrieval failed."

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/token/validators/SignatureAlgorithmEnforcementValidator.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/token/validators/SignatureAlgorithmEnforcementValidator.java
@@ -28,6 +28,7 @@ import com.wso2.openbanking.accelerator.identity.util.IdentityCommonUtil;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 
 import java.text.ParseException;
 
@@ -36,7 +37,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * Filter validator to check if the client assertion is signed with the registered algorithm.
+ * Filter validator to check if the client assertion is signed with the registered algorithm
  */
 public class SignatureAlgorithmEnforcementValidator implements OBIdentityFilterValidator {
 
@@ -66,7 +67,8 @@ public class SignatureAlgorithmEnforcementValidator implements OBIdentityFilterV
 
         if (log.isDebugEnabled()) {
             log.debug(String.format("Validating request algorithm %s against registered algorithm %s.",
-                    requestSigningAlgorithm, registeredSigningAlgorithm));
+                    requestSigningAlgorithm.replaceAll("[\r\n]" , ""),
+                    registeredSigningAlgorithm.replaceAll("[\r\n]" , "")));
         }
         if (registeredSigningAlgorithm.equals(IdentityCommonConstants.NOT_APPLICABLE)) {
             return;
@@ -89,6 +91,13 @@ public class SignatureAlgorithmEnforcementValidator implements OBIdentityFilterV
                         IdentityCommonConstants.TOKEN_ENDPOINT_AUTH_SIGNING_ALG);
             }
         } catch (OpenBankingException e) {
+            if (e.getCause() instanceof InvalidOAuthClientException) {
+                // The client_id does not correspond to an existing OAuth application (e.g. it was deleted) -
+                // surface the standard OAuth2 invalid_client error instead of a signing-algorithm-specific one.
+                throw new TokenFilterException(HttpServletResponse.SC_UNAUTHORIZED, IdentityCommonConstants
+                        .OAUTH2_INVALID_CLIENT_MESSAGE, "A valid OAuth client could not be found for client_id: "
+                        + clientId, e);
+            }
             throw new TokenFilterException(HttpServletResponse.SC_UNAUTHORIZED, IdentityCommonConstants
                     .OAUTH2_INVALID_REQUEST_MESSAGE, "Token signing algorithm not registered", e);
         }

--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/token/validators/SignatureAlgorithmEnforcementValidatorTest.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/test/java/com/wso2/openbanking/accelerator/identity/token/validators/SignatureAlgorithmEnforcementValidatorTest.java
@@ -18,12 +18,15 @@
 
 package com.wso2.openbanking.accelerator.identity.token.validators;
 
+import com.wso2.openbanking.accelerator.common.exception.OpenBankingException;
 import com.wso2.openbanking.accelerator.identity.internal.IdentityExtensionsDataHolder;
 import com.wso2.openbanking.accelerator.identity.token.DefaultTokenFilter;
 import com.wso2.openbanking.accelerator.identity.token.TokenFilter;
 import com.wso2.openbanking.accelerator.identity.token.util.TestConstants;
 import com.wso2.openbanking.accelerator.identity.token.util.TestUtil;
+import com.wso2.openbanking.accelerator.identity.token.util.TokenFilterException;
 import com.wso2.openbanking.accelerator.identity.util.IdentityCommonConstants;
+import com.wso2.openbanking.accelerator.identity.util.IdentityCommonHelper;
 import com.wso2.openbanking.accelerator.identity.util.IdentityCommonUtil;
 import org.apache.http.HttpStatus;
 import org.mockito.Mockito;
@@ -33,8 +36,10 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 
 import java.util.ArrayList;
@@ -47,11 +52,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.testng.Assert.assertEquals;
 
-/**
- * Test for signature algorithm enforcement validator.
- */
-@PowerMockIgnore("jdk.internal.reflect.*")
-@PrepareForTest({IdentityCommonUtil.class, OAuthServerConfiguration.class})
+@PrepareForTest({IdentityCommonUtil.class, OAuthServerConfiguration.class,
+        SignatureAlgorithmEnforcementValidator.class})
+@PowerMockIgnore({"jdk.internal.reflect.*"})
 public class SignatureAlgorithmEnforcementValidatorTest extends PowerMockTestCase {
 
     MockHttpServletResponse response;
@@ -211,5 +214,66 @@ public class SignatureAlgorithmEnforcementValidatorTest extends PowerMockTestCas
         assertEquals(responseMap.get(IdentityCommonConstants.OAUTH_ERROR), "invalid_request");
         assertEquals(responseMap.get(IdentityCommonConstants.OAUTH_ERROR_DESCRIPTION),
                 "Unable to find client id in the request");
+    }
+
+    @Test(description = "Test that a token request for a deleted/non-existent client_id maps to invalid_client " +
+            "at the TokenFilter's regulatory-check level, instead of a generic metadata-retrieval error")
+    public void deletedClientRegulatoryCheckMapsToInvalidClientTest() throws Exception {
+
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put(IdentityCommonConstants.CLIENT_CERTIFICATE_ENCODE, false);
+        IdentityExtensionsDataHolder.getInstance().setConfigurationMap(configMap);
+
+        PowerMockito.mockStatic(IdentityCommonUtil.class);
+        request.setParameter(IdentityCommonConstants.OAUTH_JWT_ASSERTION, TestConstants.CLIENT_ASSERTION);
+        request.setAttribute(IdentityCommonConstants.JAVAX_SERVLET_REQUEST_CERTIFICATE,
+                TestUtil.getCertificate(TestConstants.CERTIFICATE_CONTENT));
+
+        List<OBIdentityFilterValidator> validators = new ArrayList<>();
+
+        TokenFilter filter = Mockito.spy(TokenFilter.class);
+        Mockito.doReturn(new DefaultTokenFilter()).when(filter).getDefaultTokenFilter();
+        Mockito.doReturn(validators).when(filter).getValidators();
+
+        OpenBankingException clientNotFoundException = new OpenBankingException(
+                "Error retrieving service provider tenant domain for client_id: iYpRm64b2vmvmKDhdL6KZD9z6fca",
+                new InvalidOAuthClientException("A valid OAuth client could not be found"));
+        PowerMockito.when(IdentityCommonUtil.getRegulatoryFromSPMetaData("iYpRm64b2vmvmKDhdL6KZD9z6fca"))
+                .thenThrow(clientNotFoundException);
+
+        filter.doFilter(request, response, filterChain);
+
+        Map<String, String> responseMap = TestUtil.getResponse(response.getOutputStream());
+        assertEquals(response.getStatus(), HttpStatus.SC_UNAUTHORIZED);
+        assertEquals(responseMap.get(IdentityCommonConstants.OAUTH_ERROR),
+                IdentityCommonConstants.OAUTH2_INVALID_CLIENT_MESSAGE);
+        assertEquals(responseMap.get(IdentityCommonConstants.OAUTH_ERROR_DESCRIPTION),
+                "A valid OAuth client could not be found for client_id: iYpRm64b2vmvmKDhdL6KZD9z6fca");
+    }
+
+    @Test(description = "Test that SignatureAlgorithmEnforcementValidator maps a deleted/non-existent client_id " +
+            "to invalid_client instead of the misleading 'Token signing algorithm not registered' error")
+    public void deletedClientSigningAlgorithmLookupMapsToInvalidClientTest() throws Exception {
+
+        String clientId = "deletedClientId";
+        OpenBankingException clientNotFoundException = new OpenBankingException(
+                "Error retrieving service provider tenant domain for client_id: " + clientId,
+                new InvalidOAuthClientException("A valid OAuth client could not be found"));
+
+        IdentityCommonHelper mockedHelper = Mockito.mock(IdentityCommonHelper.class);
+        Mockito.when(mockedHelper.getCertificateContent(clientId)).thenThrow(clientNotFoundException);
+        PowerMockito.whenNew(IdentityCommonHelper.class).withNoArguments().thenReturn(mockedHelper);
+
+        SignatureAlgorithmEnforcementValidator validator = new SignatureAlgorithmEnforcementValidator();
+
+        try {
+            validator.getRegisteredSigningAlgorithm(clientId);
+            Assert.fail("Expected a TokenFilterException to be thrown for a non-existent client_id");
+        } catch (TokenFilterException e) {
+            assertEquals(e.getMessage(), IdentityCommonConstants.OAUTH2_INVALID_CLIENT_MESSAGE);
+            assertEquals(e.getErrorDescription(),
+                    "A valid OAuth client could not be found for client_id: " + clientId);
+            assertEquals(e.getErrorCode(), HttpServletResponse.SC_UNAUTHORIZED);
+        }
     }
 }


### PR DESCRIPTION
## [OB3] Fix misleading invalid_request error for deleted OAuth clients during token issuance

- Requesting a `client_credentials` token for a deleted DCR application returned a confusing `invalid_request / "Token signing algorithm not registered"` error instead of the standard OAuth2 invalid_client error.
- Root cause: `SignatureAlgorithmEnforcementValidator` and `TokenFilter` both collapsed any `OpenBankingException` from the SP metadata lookup into a hardcoded message, without checking whether the underlying cause was `InvalidOAuthClientException` (i.e. the client genuinely doesn't exist).
- Both call sites now detect `InvalidOAuthClientException` as the cause and return `invalid_client / "A valid OAuth client could not be found for client_id: <id>"`, matching vanilla WSO2 APIM/IS behavior.

**Issue link:** https://github.com/wso2/financial-services-accelerator/issues/981
