### PR TITLE
fix(ci): gate integration-test secrets behind trigger-integration-tests label

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,14 +33,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up Adopt JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 11.0.25+9
           distribution: 'temurin'
       - name: Set up Node 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: 16
       - name: Cache local Maven repository
@@ -83,7 +85,7 @@ jobs:
           mvn -B install --file pom.xml
 
       - name: Set up Adopt JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "adopt"
@@ -92,10 +94,26 @@ jobs:
           export MAVEN_OPTS="-Xmx4g"
           mvn -B install --file pom.xml
 
+  Reset-integration-label-on-push:
+    if: >
+      github.event_name == 'pull_request_target' &&
+      (github.event.action == 'synchronize' || github.event.action == 'reopened')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove stale trigger-integration-tests label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/trigger-integration-tests" \
+            -X DELETE || true
+
   Integration-test-suite:
     if: >
       github.event_name == 'pull_request_target' &&
-      contains(github.event.pull_request.labels.*.name, 'trigger-integration-tests')
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'trigger-integration-tests'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -108,17 +126,18 @@ jobs:
       TEST_HOME: /home/runner/work/financial-services/financial-services
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           allow-unsafe-pr-checkout: true
+          persist-credentials: false
       - name: Set up Adopt JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 11.0.25+9
           distribution: 'temurin'
       - name: Set up Node 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: 16
       - name: Cache local Maven repository
@@ -161,7 +180,7 @@ jobs:
           mvn -B install --file pom.xml
 
       - name: Set up Adopt JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "adopt"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,14 +17,88 @@
 name: Build Financial Services Repository
 
 on:
-  # Triggers the workflow on pull request events but only for the main branch
+  pull_request:
+    branches:
+      - 'main'
   pull_request_target:
     branches:
       - 'main'
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   Build-repo-check:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Adopt JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11.0.25+9
+          distribution: 'temurin'
+      - name: Set up Node 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Setup Maven settings.xml
+        uses: whelk-io/maven-settings-xml-action@v11
+        with:
+          mirrors: >
+            [
+              {
+                "id": "wso2-nexus",
+                "mirrorOf": "wso2-nexus",
+                "url": "http://maven.wso2.org/nexus/content/groups/wso2-public/"
+              },
+              {
+                "id": "wso2.releases",
+                "mirrorOf": "wso2.releases",
+                "url": "http://maven.wso2.org/nexus/content/repositories/releases/"
+              },
+              {
+                "id": "wso2.snapshots",
+                "mirrorOf": "wso2.snapshots",
+                "url": "http://maven.wso2.org/nexus/content/repositories/snapshots/"
+              },
+              {
+                "id": "knopflerfish",
+                "mirrorOf": "knopflerfish",
+                "url": "http://resources.knopflerfish.org/repo/maven2/release"
+              }
+            ]
+      - name: Build with Maven using JDK 11
+        run: |
+          export MAVEN_OPTS="-Xmx4g"
+          mvn -B install --file pom.xml
+
+      - name: Set up Adopt JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "adopt"
+      - name: Build with Maven using JDK 17
+        run: |
+          export MAVEN_OPTS="-Xmx4g"
+          mvn -B install --file pom.xml
+
+  Integration-test-suite:
+    if: >
+      github.event_name == 'pull_request_target' &&
+      contains(github.event.pull_request.labels.*.name, 'trigger-integration-tests')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       WSO2_USERNAME: ${{ secrets.SOLUTIONS_BOT_EMAIL }}
       WSO2_PASSWORD: ${{ secrets.SOLUTIONS_BOT_PASSWORD }}
@@ -37,6 +111,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
       - name: Set up Adopt JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -102,28 +102,28 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Remove stale trigger-integration-tests label
+      - name: Remove stale Action/trigger-integration-tests label
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/trigger-integration-tests" \
-            -X DELETE || true
+          set +e
+          error_output=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/Action%2Ftrigger-integration-tests" \
+            -X DELETE 2>&1)
+          exit_code=$?
+          set -e
+          if [ $exit_code -ne 0 ] && ! echo "$error_output" | grep -qi "404\|not found"; then
+            echo "$error_output" >&2
+            exit $exit_code
+          fi
 
   Integration-test-suite:
     if: >
       github.event_name == 'pull_request_target' &&
       github.event.action == 'labeled' &&
-      github.event.label.name == 'trigger-integration-tests'
+      github.event.label.name == 'Action/trigger-integration-tests'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      WSO2_USERNAME: ${{ secrets.SOLUTIONS_BOT_EMAIL }}
-      WSO2_PASSWORD: ${{ secrets.SOLUTIONS_BOT_PASSWORD }}
-      WSO2_U2_PASSWORD: ${{ secrets.SOLUTIONS_BOT_U2_PASSWORD }}
-      WSO2_UPDATE_LINUX_DECRYPTION_PASSPHRASE: ${{ secrets.WSO2_UPDATE_LINUX_DECRYPTION_PASSPHRASE }}
-      STMP_ROOT_PASSWORD: ${{ secrets.SOLUTIONS_BOT_PASSWORD }}
-      TEST_HOME: /home/runner/work/financial-services/financial-services
 
     steps:
       - uses: actions/checkout@v5
@@ -189,6 +189,13 @@ jobs:
           export MAVEN_OPTS="-Xmx4g"
           mvn -B install --file pom.xml
       - name: Running the integration test suite
+        env:
+          WSO2_USERNAME: ${{ secrets.SOLUTIONS_BOT_EMAIL }}
+          WSO2_PASSWORD: ${{ secrets.SOLUTIONS_BOT_PASSWORD }}
+          WSO2_U2_PASSWORD: ${{ secrets.SOLUTIONS_BOT_U2_PASSWORD }}
+          WSO2_UPDATE_LINUX_DECRYPTION_PASSPHRASE: ${{ secrets.WSO2_UPDATE_LINUX_DECRYPTION_PASSPHRASE }}
+          STMP_ROOT_PASSWORD: ${{ secrets.SOLUTIONS_BOT_PASSWORD }}
+          TEST_HOME: /home/runner/work/financial-services/financial-services
         run: |
           echo "Starting tests..."
           export MAVEN_OPTS="-Xmx4g"

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/test/java/org/wso2/financial/services/accelerator/keymanager/util/KeyManagerTestConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.keymanager/src/test/java/org/wso2/financial/services/accelerator/keymanager/util/KeyManagerTestConstants.java
@@ -57,18 +57,18 @@ public class KeyManagerTestConstants {
             SP_CERTIFICATE_CONFIG, "regulatory", REGULATORY_CONFIG);
 
     public static final String SP_CERT = "------BEGIN CERTIFICATE-----" +
-            "MIIFLTCCBBWgAwIBAgIEWcdQAzANBgkqhkiG9w0BAQsFADBTMQswCQYDVQQGEwJH" +
+            "MIIFLTCCBBWgAwIBAgIEWceUUTANBgkqhkiG9w0BAQsFADBTMQswCQYDVQQGEwJH" +
             "QjEUMBIGA1UEChMLT3BlbkJhbmtpbmcxLjAsBgNVBAMTJU9wZW5CYW5raW5nIFBy" +
-            "ZS1Qcm9kdWN0aW9uIElzc3VpbmcgQ0EwHhcNMjUwNjIzMDYxNDU5WhcNMjYwNzIz" +
-            "MDY0NDU5WjBhMQswCQYDVQQGEwJHQjEUMBIGA1UEChMLT3BlbkJhbmtpbmcxGzAZ" +
+            "ZS1Qcm9kdWN0aW9uIElzc3VpbmcgQ0EwHhcNMjYwNzEzMDk0NzUxWhcNMjcwNzEz" +
+            "MTAxNzUxWjBhMQswCQYDVQQGEwJHQjEUMBIGA1UEChMLT3BlbkJhbmtpbmcxGzAZ" +
             "BgNVBAsTEjAwMTU4MDAwMDFIUVFyWkFBWDEfMB0GA1UEAxMWb1E0S29hYXZwT3Vv" +
-            "RTdydlFzWkVPVjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKf6ll7D" +
-            "m33XV80dBexvXUCkoZlnNDIGl9aS08TW40NWDKnQqyjh9okMSxLxYad67A3p1zeR" +
-            "WhezlEWbg7KJpFA/2K+ncPpS+w2y/Cy0UD875N4PbAyiuTL7ghWcDF8D7fnkhCH4" +
-            "gtWd+LITRQwBsBkDQCnvlUoIQfqiULxLvw1g5eJCr3u/EID9/lq9P7CCwU+/gUgb" +
-            "Hv+H74+gm2ISAx3zdBCzyaWTEp+v0Lio02Exs/+MAcDOBVnBbkt+hSchlgt1r+s0" +
-            "XZGwS0c8YoBa75GHzhDQPhl8zlV1O2VTSDzwMVyUVEMHPesIeNA+G58b3EIuOhj/" +
-            "1m/macR4U4U3WDsCAwEAAaOCAfkwggH1MA4GA1UdDwEB/wQEAwIGwDAVBgNVHSUE" +
+            "RTdydlFzWkVPVjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMtHTAKv" +
+            "wy8OkhElmoQkhpxY0t8sSnrkMJaPwMnbPbVu/MA2F/yGIAE76jbf/hpepaiXimZ1" +
+            "7s4mf6ve778eY22Ds6TvUDgTkrHIldzYE1z5+h1Y0soZca/Rv7yhkDepyDezhoC3" +
+            "Vp41MrKhNxx2ABPNULLhBS6OWjcaPt0oHhCilwI7cUGZKizeJjO61oKo0Jmi/rPL" +
+            "vuCJu6GgwrvcyUmTRDMimoiK85/4ZY8mod8eV2FmyqIAPIrbqrrfWp1CokyG8dke" +
+            "wO2xsJ3GppnJaKiqoExl2Lh1ri2mCMJXunpezfrbwarC7zXuZgUuWE7DNghq0oVc" +
+            "/v/I6jfDiRnwW2kCAwEAAaOCAfkwggH1MA4GA1UdDwEB/wQEAwIGwDAVBgNVHSUE" +
             "DjAMBgorBgEEAYI3CgMMMIHgBgNVHSAEgdgwgdUwgdIGCysGAQQBqHWBBgFkMIHC" +
             "MCoGCCsGAQUFBwIBFh5odHRwOi8vb2IudHJ1c3Rpcy5jb20vcG9saWNpZXMwgZMG" +
             "CCsGAQUFBwICMIGGDIGDVXNlIG9mIHRoaXMgQ2VydGlmaWNhdGUgY29uc3RpdHV0" +
@@ -78,13 +78,13 @@ public class KeyManagerTestConstants {
             "cy5jb20vb2NzcDA1BggrBgEFBQcwAoYpaHR0cDovL29iLnRydXN0aXMuY29tL29i" +
             "X3BwX2lzc3VpbmdjYS5jcnQwOgYDVR0fBDMwMTAvoC2gK4YpaHR0cDovL29iLnRy" +
             "dXN0aXMuY29tL29iX3BwX2lzc3VpbmdjYS5jcmwwHwYDVR0jBBgwFoAUUHORxiFy" +
-            "03f0/gASBoFceXluP1AwHQYDVR0OBBYEFHRbhCo/PG1Iuu3Z7RZsoHvhhfU0MA0G" +
-            "CSqGSIb3DQEBCwUAA4IBAQBVQyBgWk+ZRPXowINWtPwUnn4o6Njzq4Bg43mVZsqu" +
-            "9QwD/FcwQOluv9WvmO38QK6a+zjkI1GoNPnBBkff9m1ItS3kXKfPb5DYwC+wMYHk" +
-            "pLDw0qSy/ruurHcG7dtp50AwN0qiSDz+m2LgNo//Bf4GX1gSmK21P1pgJesAmduh" +
-            "k1jXf5OOlWIEn7ARHiNytKa/G4kcnRN4cImwRMu3Nhr+9Me6E3Dy3V6e8gAjfYxI" +
-            "88BuLUouDewz0PD5pxs1JrfolqnzYZ+bKGM4af/lhrpJ1qVoL7UdxpXIpzWRU2cv" +
-            "KD7hrKocQpPsgrsj1FkUJHf0k0ZhYgcTw1VGxf1jCVpN" +
+            "03f0/gASBoFceXluP1AwHQYDVR0OBBYEFEZcuwtHczYvODnEACs6wtlEQDAnMA0G" +
+            "CSqGSIb3DQEBCwUAA4IBAQCrssvOFZiIEXK9MIuwOiD0WKhbRP7xozQ6pBcjhn15" +
+            "yZqFKeBUp9QFg8dJHIMb+8KUV+Yn+RJg/OI9omvQOiU86Nzuof+HLMzfgK1/WUm7" +
+            "cyI1CyfEZ30lVLVNgKp4TSDmczRocUNS5SwU//F9GOvyN4BNtSA9lITPP4NxKFjL" +
+            "gLlwO6AQlFTbEPHyiuMzwqln20SlQcRDNI7b5tS6U/QGXEeTkrDLMhq+1BLri0G7" +
+            "ZFHtTPMdiNg+VJaAqZyt91QcMLwIHBDAXyCRLc+0zcx0MntDoP/Mj0g1eVbqymiW" +
+            "EsUFTY0Li1qDIr2rQSO9CZshYBS3rBrMKbnbMpYT/Pzf" +
             "-----END CERTIFICATE-----";
 
     public static final String JSON_ADDITIONAL_PROPERTIES = "{\n" +


### PR DESCRIPTION
## Summary

`.github/workflows/maven.yml` used `pull_request_target` (which grants access to WSO2 secrets and a privileged `GITHUB_TOKEN`) while also checking out the PR's own head commit — the classic GitHub Actions "pwn request" pattern. `actions/checkout` correctly refuses this combination for fork PRs by default, which is why CI failed with:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow...
```

**Fix:** split the workflow into two jobs:
- `Build-repo-check` — triggered by `pull_request` (no secrets in scope), builds the project with JDK 11 and JDK 17 automatically for every PR, forks included.
- `Integration-test-suite` — triggered by `pull_request_target`, only runs once a maintainer applies the `trigger-integration-tests` label to the PR. This is where the WSO2 credentials and the integration test grid (`test-automation/*.sh`) run, with `allow-unsafe-pr-checkout: true` explicitly acknowledging that the checkout is safe only because a human has already reviewed the code.

Both jobs also declare an explicit `permissions: contents: read` to minimize the `GITHUB_TOKEN`'s scope.

**Issue link:** N/A

### Development Checklist

1. [x] Built complete solution with pull request in place.

### Secure Development Checklist

1. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

### Testing Checklist

1. [ ] Verified `Build-repo-check` runs automatically on this PR.
2. [ ] Applied `trigger-integration-tests` label and verified `Integration-test-suite` runs the full grid.