### PR TITLE
[3.0.0] Adding new consent service to revoke consents for a list of consent types and statuses

### DIFF
--- a/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/ConsentCoreService.java
+++ b/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/ConsentCoreService.java
@@ -29,6 +29,7 @@ import com.wso2.openbanking.accelerator.consent.mgt.dao.models.ConsentStatusAudi
 import com.wso2.openbanking.accelerator.consent.mgt.dao.models.DetailedConsentResource;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -224,6 +225,24 @@ public interface ConsentCoreService {
      */
     boolean revokeExistingApplicableConsents(String clientID, String userID, String consentType,
                                              String applicableStatusToRevoke, String revokedConsentStatus,
+                                             boolean shouldRevokeTokens)
+            throws ConsentManagementException;
+
+    /**
+     * This method is used to revoke existing consents for the given clientID, userID, consent types and statuses
+     * combination. Also revokes the tokens related to the consents which are revoked if the flag
+     * 'shouldRevokeTokens' is true.
+     *
+     * @param clientID ID of the client
+     * @param userID ID of the user
+     * @param consentTypes list of consent types
+     * @param applicableStatusesToRevoke list of statuses that a consent should have for revoking
+     * @param revokedConsentStatus the status should be updated the consent with after revoking
+     * @return returns true if successful
+     * @throws ConsentManagementException thrown if an error occurs in the process
+     */
+    boolean revokeExistingApplicableConsents(String clientID, String userID, List<String> consentTypes,
+                                             List<String> applicableStatusesToRevoke, String revokedConsentStatus,
                                              boolean shouldRevokeTokens)
             throws ConsentManagementException;
 

--- a/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/ConsentCoreServiceImpl.java
+++ b/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/main/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/ConsentCoreServiceImpl.java
@@ -565,6 +565,133 @@ public class ConsentCoreServiceImpl implements ConsentCoreService {
         }
     }
 
+    /**
+     * This method is used to revoke existing consents for the given clientID, userID, consent types and statuses
+     * combination. Also revokes the tokens related to the consents which are revoked if the flag
+     * 'shouldRevokeTokens' is true. If the userID is null then consents related to all the users are revoked.
+     *
+     * @param clientID ID of the client
+     * @param userID ID of the user
+     * @param consentTypes list of consent types
+     * @param applicableStatusesToRevoke list of statuses that a consent should have for revoking
+     * @param revokedConsentStatus the status should be updated the consent with after revoking
+     * @return returns true if successful
+     * @throws ConsentManagementException thrown if an error occurs in the process
+     */
+    @Override
+    public boolean revokeExistingApplicableConsents(String clientID, String userID, List<String> consentTypes,
+                                                    List<String> applicableStatusesToRevoke,
+                                                    String revokedConsentStatus, boolean shouldRevokeTokens)
+            throws ConsentManagementException {
+
+        if (StringUtils.isBlank(clientID) || StringUtils.isBlank(revokedConsentStatus)
+                || CollectionUtils.isEmpty(applicableStatusesToRevoke) || CollectionUtils.isEmpty(consentTypes)) {
+            log.error("Client ID, new consent status, consent types or applicable consent statuses to revoke is" +
+                    " missing, cannot proceed");
+            throw new ConsentManagementException("Client ID, new consent status, consent types or applicable " +
+                    "consent statuses to revoke is missing, cannot proceed");
+        }
+
+        Connection connection = DatabaseUtil.getDBConnection();
+
+        try {
+            ConsentCoreDAO consentCoreDAO = ConsentStoreInitializer.getInitializedConsentCoreDAOImpl();
+            try {
+
+                ArrayList<String> accountMappingIDsList = new ArrayList<>();
+                ArrayList<String> clientIDsList = new ArrayList<>();
+                clientIDsList.add(clientID);
+                ArrayList<String> userIDsList = new ArrayList<>();
+
+                if (userID != null) {
+                    userIDsList.add(userID);
+                }
+
+                ArrayList<String> consentTypesList = new ArrayList<>(consentTypes);
+                ArrayList<String> consentStatusesList = new ArrayList<>(applicableStatusesToRevoke);
+
+                // Get existing consents
+                log.debug("Retrieving existing consents");
+
+                // Only parameters needed for the search are provided, others are made null
+                ArrayList<DetailedConsentResource> retrievedDetailedConsentResources = consentCoreDAO
+                        .searchConsents(connection, null, clientIDsList, consentTypesList,
+                                consentStatusesList, userIDsList, null, null, null, null);
+
+                // Revoke existing consents and create audit records
+                for (DetailedConsentResource resource : retrievedDetailedConsentResources) {
+                    String previousConsentStatus = resource.getCurrentStatus();
+
+                    // Update consent status
+                    if (log.isDebugEnabled()) {
+                        log.debug("Updating consent status for consent ID: " +
+                                resource.getConsentID().replaceAll("[\r\n]", ""));
+                    }
+                    consentCoreDAO.updateConsentStatus(connection, resource.getConsentID(), revokedConsentStatus);
+
+                    // Create an audit record for consent update
+                    if (log.isDebugEnabled()) {
+                        log.debug("Creating audit record for the status change of consent ID: "
+                                + resource.getConsentID().replaceAll("[\r\n]", ""));
+                    }
+
+                    for (AuthorizationResource authorizationResource : resource.getAuthorizationResources()) {
+                        String authResourceUserId = authorizationResource.getUserID();
+
+                        if (shouldRevokeTokens) {
+                            revokeTokens(resource, authResourceUserId);
+                        }
+
+                        // Create an audit record execute state change listener
+                        HashMap<String, Object> consentDataMap = new HashMap<>();
+                        consentDataMap.put(ConsentCoreServiceConstants.DETAILED_CONSENT_RESOURCE, resource);
+                        postStateChange(connection, consentCoreDAO, resource.getConsentID(), authResourceUserId,
+                                revokedConsentStatus, previousConsentStatus,
+                                ConsentCoreServiceConstants.CONSENT_REVOKE_REASON, resource.getClientID(),
+                                consentDataMap);
+                    }
+
+                    // Extract account mapping IDs for retrieved applicable consents
+                    if (log.isDebugEnabled()) {
+                        log.debug("Extracting account mapping IDs from consent ID: " +
+                                resource.getConsentID().replaceAll("[\r\n]", ""));
+                    }
+                    for (ConsentMappingResource mappingResource : resource.getConsentMappingResources()) {
+                        accountMappingIDsList.add(mappingResource.getMappingID());
+                    }
+                }
+
+                // Update account mappings as inactive
+                log.debug("Deactivating account mappings");
+                if (accountMappingIDsList.size() > 0) {
+                    consentCoreDAO.updateConsentMappingStatus(connection, accountMappingIDsList,
+                            ConsentCoreServiceConstants.INACTIVE_MAPPING_STATUS);
+                }
+                //Commit transaction
+                DatabaseUtil.commitTransaction(connection);
+                log.debug(ConsentCoreServiceConstants.TRANSACTION_COMMITTED_LOG_MSG);
+                return true;
+            } catch (OBConsentDataRetrievalException e) {
+                log.error(ConsentCoreServiceConstants.DATA_RETRIEVE_ERROR_MSG, e);
+                throw new ConsentManagementException(ConsentCoreServiceConstants.DATA_RETRIEVE_ERROR_MSG, e);
+            } catch (OBConsentDataInsertionException e) {
+                log.error(ConsentCoreServiceConstants.DATA_INSERTION_ROLLBACK_ERROR_MSG, e);
+                DatabaseUtil.rollbackTransaction(connection);
+                throw new ConsentManagementException(ConsentCoreServiceConstants.DATA_INSERTION_ROLLBACK_ERROR_MSG, e);
+            } catch (OBConsentDataUpdationException e) {
+                log.error(ConsentCoreServiceConstants.DATA_UPDATE_ROLLBACK_ERROR_MSG, e);
+                DatabaseUtil.rollbackTransaction(connection);
+                throw new ConsentManagementException(ConsentCoreServiceConstants.DATA_UPDATE_ROLLBACK_ERROR_MSG, e);
+            } catch (IdentityOAuth2Exception e) {
+                log.error("Error while revoking tokens for existing consents", e);
+                throw new ConsentManagementException("Error occurred while revoking tokens for existing consents");
+            }
+        } finally {
+            log.debug(ConsentCoreServiceConstants.DATABASE_CONNECTION_CLOSE_LOG_MSG);
+            DatabaseUtil.closeConnection(connection);
+        }
+    }
+
     @Override
     public ConsentResource getConsent(String consentID, boolean withAttributes)
             throws ConsentManagementException {

--- a/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/test/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/OBConsentMgtCoreServiceTests.java
+++ b/open-banking-accelerator/components/consent-management/com.wso2.openbanking.accelerator.consent.mgt.service/src/test/java/com/wso2/openbanking/accelerator/consent/mgt/service/impl/OBConsentMgtCoreServiceTests.java
@@ -60,8 +60,10 @@ import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -823,6 +825,210 @@ public class OBConsentMgtCoreServiceTests {
                 ConsentMgtServiceTestData.SAMPLE_USER_ID, ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE,
                 null, ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS
                 , false);
+    }
+
+    @Test
+    public void testRevokeExistingApplicableConsentsWithConsentTypesAndStatusesList() throws Exception {
+
+        ArrayList<DetailedConsentResource> detailedConsentResources = new ArrayList<>();
+        detailedConsentResources.add(ConsentMgtServiceTestData.getSampleDetailedStoredTestConsentResource());
+
+        Mockito.doReturn(detailedConsentResources).when(mockedConsentCoreDAO)
+                .searchConsents(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentResource()).when(mockedConsentCoreDAO)
+                .updateConsentStatus(Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentStatusAuditRecord(sampleID,
+                        ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS)).when(mockedConsentCoreDAO)
+                .storeConsentStatusAuditRecord(Mockito.any(), Mockito.anyObject());
+        Mockito.doReturn(true).when(mockedConsentCoreDAO).updateConsentMappingStatus(Mockito.any(),
+                Mockito.any(), Mockito.any());
+
+        Assert.assertTrue(consentCoreServiceImpl.revokeExistingApplicableConsents(sampleID,
+                ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false));
+    }
+
+    @Test
+    public void testRevokeExistingApplicableConsentsWithConsentTypesAndStatusesListWithTokens() throws Exception {
+
+        ArrayList<DetailedConsentResource> detailedConsentResources = new ArrayList<>();
+        detailedConsentResources.add(ConsentMgtServiceTestData.getSampleDetailedStoredTestConsentResource());
+
+        Mockito.doReturn(detailedConsentResources).when(mockedConsentCoreDAO)
+                .searchConsents(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentResource()).when(mockedConsentCoreDAO)
+                .updateConsentStatus(Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentStatusAuditRecord(sampleID,
+                        ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS)).when(mockedConsentCoreDAO)
+                .storeConsentStatusAuditRecord(Mockito.any(), Mockito.anyObject());
+        Mockito.doReturn(true).when(mockedConsentCoreDAO).updateConsentMappingStatus(Mockito.any(),
+                Mockito.any(), Mockito.any());
+
+        Assert.assertTrue(new MockConsentCoreServiceImpl().revokeExistingApplicableConsents(sampleID,
+                ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, true));
+    }
+
+    @Test
+    public void testRevokeExistingApplicableConsentsWithConsentTypesAndStatusesListWithNoAttributes()
+            throws Exception {
+
+        DetailedConsentResource detailedConsentResource =
+                ConsentMgtServiceTestData.getSampleDetailedStoredTestConsentResource();
+        detailedConsentResource.setConsentAttributes(null);
+
+        ArrayList<DetailedConsentResource> detailedConsentResources = new ArrayList<>();
+        detailedConsentResources.add(detailedConsentResource);
+
+        Mockito.doReturn(detailedConsentResources).when(mockedConsentCoreDAO)
+                .searchConsents(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentResource()).when(mockedConsentCoreDAO)
+                .updateConsentStatus(Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentStatusAuditRecord(sampleID,
+                        ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS)).when(mockedConsentCoreDAO)
+                .storeConsentStatusAuditRecord(Mockito.any(), Mockito.anyObject());
+        Mockito.doReturn(true).when(mockedConsentCoreDAO).updateConsentMappingStatus(Mockito.any(),
+                Mockito.any(), Mockito.any());
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(sampleID, ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsRetrieveError() throws Exception {
+
+        Mockito.doThrow(OBConsentDataRetrievalException.class).when(mockedConsentCoreDAO)
+                .searchConsents(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt());
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(sampleID, ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsUpdateError() throws Exception {
+
+        ArrayList<DetailedConsentResource> detailedConsentResources = new ArrayList<>();
+        detailedConsentResources.add(ConsentMgtServiceTestData.getSampleDetailedStoredTestConsentResource());
+
+        Mockito.doReturn(detailedConsentResources).when(mockedConsentCoreDAO)
+                .searchConsents(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt());
+        Mockito.doThrow(OBConsentDataUpdationException.class).when(mockedConsentCoreDAO)
+                .updateConsentStatus(Mockito.any(), Mockito.anyString(), Mockito.anyString());
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(sampleID, ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsInsertionError() throws Exception {
+
+        ArrayList<DetailedConsentResource> detailedConsentResources = new ArrayList<>();
+        detailedConsentResources.add(ConsentMgtServiceTestData.getSampleDetailedStoredTestConsentResource());
+
+        Mockito.doReturn(detailedConsentResources).when(mockedConsentCoreDAO)
+                .searchConsents(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentResource()).when(mockedConsentCoreDAO)
+                .updateConsentStatus(Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.doThrow(OBConsentDataInsertionException.class).when(mockedConsentCoreDAO)
+                .storeConsentStatusAuditRecord(Mockito.any(), Mockito.anyObject());
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(sampleID, ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsWithoutClientID() throws Exception {
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(null, ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsWithoutRevokedConsentStatus() throws Exception {
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(ConsentMgtServiceTestData.SAMPLE_CLIENT_ID,
+                ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS), null, false);
+    }
+
+    @Test
+    public void testRevokeExistingApplicableConsentsWithListsWithoutUserID() throws Exception {
+
+        ArrayList<DetailedConsentResource> detailedConsentResources = new ArrayList<>();
+        detailedConsentResources.add(ConsentMgtServiceTestData.getSampleDetailedStoredTestConsentResource());
+
+        Mockito.doReturn(detailedConsentResources).when(mockedConsentCoreDAO)
+                .searchConsents(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.anyLong(), Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentResource()).when(mockedConsentCoreDAO)
+                .updateConsentStatus(Mockito.any(), Mockito.anyString(), Mockito.anyString());
+        Mockito.doReturn(ConsentMgtServiceTestData.getSampleStoredTestConsentStatusAuditRecord(sampleID,
+                        ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS)).when(mockedConsentCoreDAO)
+                .storeConsentStatusAuditRecord(Mockito.any(), Mockito.anyObject());
+        Mockito.doReturn(true).when(mockedConsentCoreDAO).updateConsentMappingStatus(Mockito.any(),
+                Mockito.any(), Mockito.any());
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(ConsentMgtServiceTestData.SAMPLE_CLIENT_ID,
+                null, Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsWithoutConsentTypes() throws Exception {
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(ConsentMgtServiceTestData.SAMPLE_CLIENT_ID,
+                ConsentMgtServiceTestData.SAMPLE_USER_ID, (List<String>) null,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsWithoutApplicableStatusesToRevoke() throws Exception {
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(ConsentMgtServiceTestData.SAMPLE_CLIENT_ID,
+                ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                (List<String>) null, ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsWithEmptyConsentTypes() throws Exception {
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(ConsentMgtServiceTestData.SAMPLE_CLIENT_ID,
+                ConsentMgtServiceTestData.SAMPLE_USER_ID, Collections.emptyList(),
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS),
+                ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
+    }
+
+    @Test (expectedExceptions = ConsentManagementException.class)
+    public void testRevokeExistingApplicableConsentsWithListsWithEmptyApplicableStatusesToRevoke() throws Exception {
+
+        consentCoreServiceImpl.revokeExistingApplicableConsents(ConsentMgtServiceTestData.SAMPLE_CLIENT_ID,
+                ConsentMgtServiceTestData.SAMPLE_USER_ID,
+                Collections.singletonList(ConsentMgtServiceTestData.SAMPLE_CONSENT_TYPE),
+                Collections.emptyList(), ConsentMgtServiceTestData.SAMPLE_CURRENT_STATUS, false);
     }
 
     @Test (expectedExceptions = ConsentManagementException.class)


### PR DESCRIPTION
## Adding new consent service to revoke consents for a list of consent types and statuses

> This PR adds a new method to the consent core service to revoke existing consents for the given clientID, userID, consent types, and statuses combination. Also revokes the tokens related to the consents which are revoked if the flag 'shouldRevokeTokens' is true. If the userID is null, then consents related to all the users are revoked.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/981*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
