### PR TITLE
[3.0.0] Fix issue in token revocation logic when app is deleted

### DIFF
--- a/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/util/IdentityCommonHelper.java
+++ b/open-banking-accelerator/components/com.wso2.openbanking.accelerator.identity/src/main/java/com/wso2/openbanking/accelerator/identity/util/IdentityCommonHelper.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.oauth2.bean.OAuthClientAuthnContext;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
 import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuthRevocationResponseDTO;
+import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -243,8 +244,8 @@ public class IdentityCommonHelper {
             return;
         }
 
-        Set<String> activeTokens = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
-                .getActiveTokensByConsumerKey(clientId);
+        Set<AccessTokenDO> activeTokens = OAuthTokenPersistenceFactory.getInstance().getAccessTokenDAO()
+                .getActiveAcessTokenDataByConsumerKey(clientId);
         if (!activeTokens.isEmpty()) {
             OAuthClientAuthnContext oAuthClientAuthnContext = new OAuthClientAuthnContext();
             oAuthClientAuthnContext.setAuthenticated(true);
@@ -255,15 +256,18 @@ public class IdentityCommonHelper {
             revocationRequestDTO.setConsumerKey(clientId);
             revocationRequestDTO.setTokenType(GrantType.REFRESH_TOKEN.toString());
 
-            for (String accessToken : activeTokens) {
-                revocationRequestDTO.setToken(accessToken);
-                OAuthRevocationResponseDTO oAuthRevocationResponseDTO =  IdentityExtensionsDataHolder.getInstance()
-                        .getOAuth2Service().revokeTokenByOAuthClient(revocationRequestDTO);
+            for (AccessTokenDO accessToken : activeTokens) {
+                if (accessToken.getRefreshToken() != null) {
 
-                if (oAuthRevocationResponseDTO.isError()) {
-                    throw new IdentityOAuth2Exception(
-                            String.format("Error occurred while revoking access tokens for clientId: %s. Caused by, %s",
-                                    clientId, oAuthRevocationResponseDTO.getErrorMsg()));
+                    revocationRequestDTO.setToken(accessToken.getRefreshToken());
+                    OAuthRevocationResponseDTO oAuthRevocationResponseDTO = IdentityExtensionsDataHolder.getInstance()
+                            .getOAuth2Service().revokeTokenByOAuthClient(revocationRequestDTO);
+
+                    if (oAuthRevocationResponseDTO.isError()) {
+                        throw new IdentityOAuth2Exception(
+                                String.format("Error occurred while revoking access tokens for clientId: %s. " +
+                                        "Caused by, %s", clientId, oAuthRevocationResponseDTO.getErrorMsg()));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Fix issue in token revocation logic when app is deleted

> This PR fixes an issue in token revocation logic when the application is deleted. In the previous implementation, we used 'getActiveTokensByConsumerKey' which will return the information only about the access token (token identifier of the JWT) and tried to revoke them by setting the token type as `refresh_token`. Updated the implementation to get access token data using `getActiveAcessTokenDataByConsumerKey` method and set the refresh token as the token in the `OAuthRevocationRequestDTO`.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/981*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
