### PR TITLE
Fixing security issues in Consent and Event Subscription Modules

### DIFF
--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/impl/DefaultConsentManageHandler.java
@@ -602,6 +602,12 @@ public class DefaultConsentManageHandler implements ConsentManageHandler {
                         ConsentOperationEnum.CONSENT_FILE_UPLOAD);
             }
 
+            if (!consentResource.getClientID().equals(consentManageData.getClientId())) {
+                log.error(ConsentManageConstants.CLIENT_ID_MISMATCH_ERROR);
+                throw new ConsentException(ResponseStatus.BAD_REQUEST, ConsentManageConstants.CLIENT_ID_MISMATCH_ERROR,
+                        ConsentOperationEnum.CONSENT_FILE_UPLOAD);
+            }
+
             Object fileFromRequest = consentManageData.getPayload();
             if (!(fileFromRequest instanceof String)) {
                 log.error("Invalid file content found in the request.");

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/validate/impl/DefaultConsentValidator.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/main/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/validate/impl/DefaultConsentValidator.java
@@ -20,6 +20,7 @@ package org.wso2.financial.services.accelerator.consent.mgt.extensions.validate.
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpStatus;
@@ -35,6 +36,7 @@ import org.wso2.financial.services.accelerator.common.extension.model.StatusEnum
 import org.wso2.financial.services.accelerator.common.util.FinancialServicesUtils;
 import org.wso2.financial.services.accelerator.common.util.ServiceExtensionUtils;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.AuthorizationResource;
+import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentMappingResource;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.DetailedConsentResource;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentException;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionConstants;
@@ -44,11 +46,14 @@ import org.wso2.financial.services.accelerator.consent.mgt.extensions.validate.C
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.validate.model.ConsentValidateData;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.validate.model.ConsentValidateRequest;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.validate.model.ConsentValidationResult;
+import org.wso2.financial.services.accelerator.consent.mgt.service.constants.ConsentCoreServiceConstants;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Consent validator default implementation.
@@ -60,11 +65,14 @@ public class DefaultConsentValidator implements ConsentValidator {
     private static final String ACCOUNTS_REGEX = "/accounts/[^/?]*";
     private static final String TRANSACTIONS_REGEX = "/accounts/[^/?]*/transactions";
     private static final String BALANCES_REGEX = "/accounts/[^/?]*/balances";
+    private static final Pattern ACCOUNT_ID_PATH_PATTERN =
+            Pattern.compile("^/accounts/([^/?]+)(?:/transactions|/balances)?$");
     private static final String COF_SUBMISSION_PATH = "/funds-confirmations";
     private static final String PERMISSION_MISMATCH_ERROR = "Permission mismatch. Consent does not contain necessary " +
             "permissions";
     private static final String INVALID_URI_ERROR = "Path requested is invalid";
     private static final String CONSENT_EXPIRED_ERROR = "Provided consent is expired";
+    private static final String INVALID_ACCOUNT_ID_ERROR = "Account Id requested is not consented for the user";
 
     @Override
     public void validate(ConsentValidateData consentValidateData, ConsentValidationResult consentValidationResult)
@@ -289,6 +297,20 @@ public class DefaultConsentValidator implements ConsentValidator {
             consentValidationResult.setErrorCode(ResponseStatus.FORBIDDEN.getReasonPhrase());
             consentValidationResult.setHttpCode(HttpStatus.SC_FORBIDDEN);
             return;
+        }
+
+        // Perform Account Id Validation for endpoints that carry an account id in the request path.
+        if (!uri.matches(ACCOUNTS_BULK_REGEX)) {
+            String accountId = extractAccountIdFromPath(uri);
+            if (StringUtils.isBlank(accountId) ||
+                    !isAccountIdConsented(accountId, consentValidateData.getComprehensiveConsent())) {
+                log.error(INVALID_ACCOUNT_ID_ERROR);
+                consentValidationResult.setValid(false);
+                consentValidationResult.setErrorMessage(INVALID_ACCOUNT_ID_ERROR);
+                consentValidationResult.setErrorCode(ResponseStatus.UNAUTHORIZED.getReasonPhrase());
+                consentValidationResult.setHttpCode(HttpStatus.SC_UNAUTHORIZED);
+                return;
+            }
         }
 
         //Consent Status Validation
@@ -517,5 +539,44 @@ public class DefaultConsentValidator implements ConsentValidator {
             log.error("Error occurred while comparing the JSON Objects", e);
             return false;
         }
+    }
+
+    /**
+     * Extract the account id sent in the request path for account retrieval endpoints.
+     *
+     * @param uri  Request URI
+     * @return  Account id present in the path, null if not found
+     */
+    private static String extractAccountIdFromPath(String uri) {
+
+        Matcher matcher = ACCOUNT_ID_PATH_PATTERN.matcher(uri);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * Check whether the given account id is present in the active consent mapping resources of the consent.
+     *
+     * @param accountId              Account id extracted from the request path
+     * @param comprehensiveConsent   Consent resource containing the consent mapping resources
+     * @return  Whether the account id is consented
+     */
+    private static boolean isAccountIdConsented(String accountId, DetailedConsentResource comprehensiveConsent) {
+
+        ArrayList<ConsentMappingResource> consentMappingResources =
+                comprehensiveConsent.getConsentMappingResources();
+        if (consentMappingResources == null) {
+            return false;
+        }
+
+        for (ConsentMappingResource mappingResource : consentMappingResources) {
+            if (accountId.equals(mappingResource.getAccountID()) &&
+                    ConsentCoreServiceConstants.ACTIVE_MAPPING_STATUS.equals(mappingResource.getMappingStatus())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/DefaultConsentManageHandlerTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/manage/DefaultConsentManageHandlerTest.java
@@ -427,7 +427,7 @@ public class DefaultConsentManageHandlerTest {
         defaultConsentManageHandler.handleFileUploadPost(consentManageDataMock);
 
         Mockito.verify(consentManageDataMock).getRequestPath();
-        Mockito.verify(consentManageDataMock, Mockito.times(2)).getClientId();
+        Mockito.verify(consentManageDataMock, Mockito.times(3)).getClientId();
         Mockito.verify(consentManageDataMock).setResponseStatus(ResponseStatus.OK);
     }
 
@@ -452,7 +452,7 @@ public class DefaultConsentManageHandlerTest {
             externalServiceConsentManageHandler.handleFileUploadPost(consentManageDataMock);
 
             Mockito.verify(consentManageDataMock, Mockito.times(2)).getRequestPath();
-            Mockito.verify(consentManageDataMock, Mockito.times(2)).getClientId();
+            Mockito.verify(consentManageDataMock, Mockito.times(3)).getClientId();
             Mockito.verify(consentManageDataMock).setResponseStatus(ResponseStatus.OK);
         }
     }

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/validate/DefaultConsentValidatorTest.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.consent.mgt.extensions/src/test/java/org/wso2/financial/services/accelerator/consent/mgt/extensions/validate/DefaultConsentValidatorTest.java
@@ -36,6 +36,7 @@ import org.wso2.financial.services.accelerator.common.extension.model.StatusEnum
 import org.wso2.financial.services.accelerator.common.util.FinancialServicesUtils;
 import org.wso2.financial.services.accelerator.common.util.ServiceExtensionUtils;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.AuthorizationResource;
+import org.wso2.financial.services.accelerator.consent.mgt.dao.models.ConsentMappingResource;
 import org.wso2.financial.services.accelerator.consent.mgt.dao.models.DetailedConsentResource;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ConsentExtensionConstants;
 import org.wso2.financial.services.accelerator.consent.mgt.extensions.common.ResponseStatus;
@@ -318,6 +319,117 @@ public class DefaultConsentValidatorTest {
         Assert.assertEquals(consentValidationResultMock.getErrorMessage(), "Permission mismatch. " +
                 "Consent does not contain necessary permissions");
         Assert.assertEquals(consentValidationResultMock.getHttpCode(), HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void testValidateWithInvalidAccountIdForAccounts() {
+
+        FinancialServicesConfigParser configParserMock = Mockito.mock(FinancialServicesConfigParser.class);
+        Mockito.doReturn(false).when(configParserMock).isServiceExtensionsEndpointEnabled();
+        Mockito.doReturn(Collections.emptyList()).when(configParserMock).getServiceExtensionTypes();
+        financialServicesConfigParserMockedStatic.when(FinancialServicesConfigParser::getInstance)
+                .thenReturn(configParserMock);
+
+        serviceExtensionUtilsMockedStatic.when(() -> ServiceExtensionUtils
+                .isInvokeExternalService(any())).thenReturn(false);
+
+        DetailedConsentResource consentResource = mock(DetailedConsentResource.class);
+        doReturn(TestConstants.VALID_INITIATION).when(consentResource).getReceipt();
+        ArrayList<AuthorizationResource> authResources = TestUtil.getSampleAuthorizationResourceArray(
+                TestConstants.SAMPLE_CONSENT_ID, TestConstants.SAMPLE_AUTH_ID);
+        doReturn(authResources).when(consentResource).getAuthorizationResources();
+        doReturn(TestConstants.SAMPLE_CLIENT_ID).when(consentResource).getClientID();
+        doReturn(TestConstants.ACCOUNTS).when(consentResource).getConsentType();
+        ArrayList<ConsentMappingResource> consentMappingResources = new ArrayList<>(List.of(
+                TestUtil.getSampleConsentMappingResource(TestConstants.SAMPLE_AUTH_ID)));
+        doReturn(consentMappingResources).when(consentResource).getConsentMappingResources();
+
+        doReturn(consentResource).when(consentValidateDataMock).getComprehensiveConsent();
+        doReturn(TestConstants.SAMPLE_USER_ID).when(consentValidateDataMock).getUserId();
+        doReturn(TestConstants.SAMPLE_CLIENT_ID).when(consentValidateDataMock).getClientId();
+        doReturn("/accounts/invalid-account-id").when(consentValidateDataMock).getRequestPath();
+
+        validator.validate(consentValidateDataMock, consentValidationResultMock);
+
+        Assert.assertFalse(consentValidationResultMock.isValid());
+        Assert.assertEquals(consentValidationResultMock.getErrorCode(), ResponseStatus.UNAUTHORIZED.getReasonPhrase());
+        Assert.assertEquals(consentValidationResultMock.getErrorMessage(),
+                "Account Id requested is not consented for the user");
+        Assert.assertEquals(consentValidationResultMock.getHttpCode(), HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void testValidateWithInactiveAccountIdForAccounts() {
+
+        FinancialServicesConfigParser configParserMock = Mockito.mock(FinancialServicesConfigParser.class);
+        Mockito.doReturn(false).when(configParserMock).isServiceExtensionsEndpointEnabled();
+        Mockito.doReturn(Collections.emptyList()).when(configParserMock).getServiceExtensionTypes();
+        financialServicesConfigParserMockedStatic.when(FinancialServicesConfigParser::getInstance)
+                .thenReturn(configParserMock);
+
+        serviceExtensionUtilsMockedStatic.when(() -> ServiceExtensionUtils
+                .isInvokeExternalService(any())).thenReturn(false);
+
+        DetailedConsentResource consentResource = mock(DetailedConsentResource.class);
+        doReturn(TestConstants.VALID_INITIATION).when(consentResource).getReceipt();
+        ArrayList<AuthorizationResource> authResources = TestUtil.getSampleAuthorizationResourceArray(
+                TestConstants.SAMPLE_CONSENT_ID, TestConstants.SAMPLE_AUTH_ID);
+        doReturn(authResources).when(consentResource).getAuthorizationResources();
+        doReturn(TestConstants.SAMPLE_CLIENT_ID).when(consentResource).getClientID();
+        doReturn(TestConstants.ACCOUNTS).when(consentResource).getConsentType();
+        ArrayList<ConsentMappingResource> consentMappingResources = new ArrayList<>(List.of(
+                TestUtil.getSampleInactiveConsentMappingResource(TestConstants.SAMPLE_AUTH_ID)));
+        doReturn(consentMappingResources).when(consentResource).getConsentMappingResources();
+
+        doReturn(consentResource).when(consentValidateDataMock).getComprehensiveConsent();
+        doReturn(TestConstants.SAMPLE_USER_ID).when(consentValidateDataMock).getUserId();
+        doReturn(TestConstants.SAMPLE_CLIENT_ID).when(consentValidateDataMock).getClientId();
+        doReturn("/accounts/" + TestConstants.SAMPLE_ACCOUNT_ID).when(consentValidateDataMock).getRequestPath();
+
+        validator.validate(consentValidateDataMock, consentValidationResultMock);
+
+        Assert.assertFalse(consentValidationResultMock.isValid());
+        Assert.assertEquals(consentValidationResultMock.getErrorCode(), ResponseStatus.UNAUTHORIZED.getReasonPhrase());
+        Assert.assertEquals(consentValidationResultMock.getErrorMessage(),
+                "Account Id requested is not consented for the user");
+        Assert.assertEquals(consentValidationResultMock.getHttpCode(), HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void testValidateWithValidAccountIdForAccounts() {
+
+        FinancialServicesConfigParser configParserMock = Mockito.mock(FinancialServicesConfigParser.class);
+        Mockito.doReturn(false).when(configParserMock).isServiceExtensionsEndpointEnabled();
+        Mockito.doReturn(Collections.emptyList()).when(configParserMock).getServiceExtensionTypes();
+        financialServicesConfigParserMockedStatic.when(FinancialServicesConfigParser::getInstance)
+                .thenReturn(configParserMock);
+
+        serviceExtensionUtilsMockedStatic.when(() -> ServiceExtensionUtils
+                .isInvokeExternalService(any())).thenReturn(false);
+
+        DetailedConsentResource consentResource = mock(DetailedConsentResource.class);
+        doReturn(TestConstants.VALID_INITIATION).when(consentResource).getReceipt();
+        ArrayList<AuthorizationResource> authResources = TestUtil.getSampleAuthorizationResourceArray(
+                TestConstants.SAMPLE_CONSENT_ID, TestConstants.SAMPLE_AUTH_ID);
+        doReturn(authResources).when(consentResource).getAuthorizationResources();
+        doReturn(TestConstants.SAMPLE_CLIENT_ID).when(consentResource).getClientID();
+        doReturn(TestConstants.ACCOUNTS).when(consentResource).getConsentType();
+        doReturn(TestConstants.AUTHORISED_STATUS).when(consentResource).getCurrentStatus();
+        ArrayList<ConsentMappingResource> consentMappingResources = new ArrayList<>(List.of(
+                TestUtil.getSampleConsentMappingResource(TestConstants.SAMPLE_AUTH_ID),
+                TestUtil.getSampleInactiveConsentMappingResource(TestConstants.SAMPLE_AUTH_ID)));
+        doReturn(consentMappingResources).when(consentResource).getConsentMappingResources();
+
+        doReturn(consentResource).when(consentValidateDataMock).getComprehensiveConsent();
+        doReturn(TestConstants.SAMPLE_USER_ID).when(consentValidateDataMock).getUserId();
+        doReturn(TestConstants.SAMPLE_CLIENT_ID).when(consentValidateDataMock).getClientId();
+        doReturn("/accounts/" + TestConstants.SAMPLE_ACCOUNT_ID + "/transactions")
+                .when(consentValidateDataMock).getRequestPath();
+        doReturn(TestConstants.SAMPLE_CONSENT_ID).when(consentValidateDataMock).getConsentId();
+
+        validator.validate(consentValidateDataMock, consentValidationResultMock);
+
+        Assert.assertTrue(consentValidationResultMock.isValid());
     }
 
     @Test

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.event.notifications.service/src/main/java/org/wso2/financial/services/accelerator/event/notifications/service/constants/EventNotificationConstants.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.event.notifications.service/src/main/java/org/wso2/financial/services/accelerator/event/notifications/service/constants/EventNotificationConstants.java
@@ -158,6 +158,8 @@ public class EventNotificationConstants {
     public static final String SUBSCRIPTION_EXISTS = "Subscription Resource already exists for the client";
     public static final String SUBSCRIPTION_RESOURCE_NOT_FOUND = "A subscription Resource does not exists for" +
             " the client";
+    public static final String CLIENT_ID_MISMATCH_ERROR = "Client Id in the request does not match with the client Id" +
+            " associated to the event subscription";
 
     public static final String EVENT_DATA = "eventData";
     public static final String EVENT_POLLING_DATA = "eventPollingData";

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.event.notifications.service/src/main/java/org/wso2/financial/services/accelerator/event/notifications/service/handler/DefaultEventSubscriptionServiceHandler.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.event.notifications.service/src/main/java/org/wso2/financial/services/accelerator/event/notifications/service/handler/DefaultEventSubscriptionServiceHandler.java
@@ -133,6 +133,15 @@ public class DefaultEventSubscriptionServiceHandler implements EventSubscription
             EventSubscription eventSubscription = eventSubscriptionService.
                     getEventSubscriptionBySubscriptionId(subscriptionId);
 
+            if (!clientId.equals(eventSubscription.getClientId())) {
+                log.error(EventNotificationConstants.CLIENT_ID_MISMATCH_ERROR);
+                eventSubscriptionResponse.setResponseStatus(HttpStatus.SC_BAD_REQUEST);
+                eventSubscriptionResponse.setResponseBody(EventNotificationServiceUtil.getErrorDTO(
+                        EventNotificationConstants.INVALID_REQUEST,
+                        EventNotificationConstants.CLIENT_ID_MISMATCH_ERROR));
+                return eventSubscriptionResponse;
+            }
+
             EventSubscriptionResponse externalServiceResponse =  handleValidation(new JSONObject(eventSubscription),
                     EventSubscriptionOperationEnum.SingleSubscriptionRetrieval);
             if (externalServiceResponse != null) {
@@ -250,6 +259,18 @@ public class DefaultEventSubscriptionServiceHandler implements EventSubscription
 
         try {
 
+            EventSubscription existingEventSubscription = eventSubscriptionService.
+                    getEventSubscriptionBySubscriptionId(eventSubscriptionUpdateRequestDto.getSubscriptionId());
+
+            if (!eventSubscriptionUpdateRequestDto.getClientId().equals(existingEventSubscription.getClientId())) {
+                log.error(EventNotificationConstants.CLIENT_ID_MISMATCH_ERROR);
+                eventSubscriptionResponse.setResponseStatus(HttpStatus.SC_BAD_REQUEST);
+                eventSubscriptionResponse.setResponseBody(EventNotificationServiceUtil.getErrorDTO(
+                        EventNotificationConstants.INVALID_REQUEST,
+                        EventNotificationConstants.CLIENT_ID_MISMATCH_ERROR));
+                return eventSubscriptionResponse;
+            }
+
             EventSubscriptionResponse externalServiceResponse = handleValidation(
                     new JSONObject(eventSubscriptionUpdateRequestDto),
                     EventSubscriptionOperationEnum.SubscriptionUpdate);
@@ -286,10 +307,17 @@ public class DefaultEventSubscriptionServiceHandler implements EventSubscription
             return eventSubscriptionResponse;
         } catch (FSEventNotificationException e) {
             log.error("Error occurred while updating event subscription", e);
-            eventSubscriptionResponse.setResponseStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-            eventSubscriptionResponse.setResponseBody(EventNotificationServiceUtil.getErrorDTO(
-                    EventNotificationConstants.INVALID_REQUEST, e.getMessage()));
-            return eventSubscriptionResponse;
+            if (e.getMessage().equals(EventNotificationConstants.EVENT_SUBSCRIPTION_NOT_FOUND)) {
+                eventSubscriptionResponse.setResponseStatus(HttpStatus.SC_BAD_REQUEST);
+                eventSubscriptionResponse.setResponseBody(EventNotificationServiceUtil.getErrorDTO(
+                        EventNotificationConstants.INVALID_REQUEST, e.getMessage()));
+                return eventSubscriptionResponse;
+            } else {
+                eventSubscriptionResponse.setResponseStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                eventSubscriptionResponse.setResponseBody(EventNotificationServiceUtil.getErrorDTO(
+                        EventNotificationConstants.INVALID_REQUEST, e.getMessage()));
+                return eventSubscriptionResponse;
+            }
         }
     }
 
@@ -308,6 +336,15 @@ public class DefaultEventSubscriptionServiceHandler implements EventSubscription
 
             EventSubscription eventSubscription = eventSubscriptionService.
                     getEventSubscriptionBySubscriptionId(subscriptionId);
+
+            if (!clientId.equals(eventSubscription.getClientId())) {
+                log.error(EventNotificationConstants.CLIENT_ID_MISMATCH_ERROR);
+                eventSubscriptionResponse.setResponseStatus(org.apache.commons.httpclient.HttpStatus.SC_BAD_REQUEST);
+                eventSubscriptionResponse.setResponseBody(EventNotificationServiceUtil.getErrorDTO(
+                        EventNotificationConstants.INVALID_REQUEST,
+                        EventNotificationConstants.CLIENT_ID_MISMATCH_ERROR));
+                return eventSubscriptionResponse;
+            }
 
             EventSubscriptionResponse externalServiceResponse = handleValidation(new JSONObject(eventSubscription),
                     EventSubscriptionOperationEnum.SubscriptionDelete);

--- a/financial-services-accelerator/components/org.wso2.financial.services.accelerator.event.notifications.service/src/test/java/org/wso2/financial/services/accelerator/event/notifications/service/handler/DefaultEventSubscriptionServiceHandlerTests.java
+++ b/financial-services-accelerator/components/org.wso2.financial.services.accelerator.event.notifications.service/src/test/java/org/wso2/financial/services/accelerator/event/notifications/service/handler/DefaultEventSubscriptionServiceHandlerTests.java
@@ -33,6 +33,7 @@ import org.wso2.financial.services.accelerator.common.util.ServiceExtensionUtils
 import org.wso2.financial.services.accelerator.event.notifications.service.EventSubscriptionService;
 import org.wso2.financial.services.accelerator.event.notifications.service.constants.EventNotificationConstants;
 import org.wso2.financial.services.accelerator.event.notifications.service.constants.EventNotificationTestConstants;
+import org.wso2.financial.services.accelerator.event.notifications.service.dto.EventSubscriptionDTO;
 import org.wso2.financial.services.accelerator.event.notifications.service.exception.FSEventNotificationException;
 import org.wso2.financial.services.accelerator.event.notifications.service.model.EventSubscriptionResponse;
 import org.wso2.financial.services.accelerator.event.notifications.service.util.EventNotificationServiceUtil;
@@ -217,6 +218,26 @@ public class DefaultEventSubscriptionServiceHandlerTests {
 
         EventSubscriptionResponse eventSubscriptionRetrieveResponse = defaultEventSubscriptionServiceHandler
                 .getEventSubscription(EventNotificationTestConstants.SAMPLE_CLIENT_ID,
+                        EventNotificationTestConstants.SAMPLE_SUBSCRIPTION_ID_1);
+
+        Assert.assertEquals(eventSubscriptionRetrieveResponse.getResponseStatus(), HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testGetEventSubscriptionWithClientIdMismatch() throws Exception {
+        EventSubscriptionService eventSubscriptionService = Mockito.mock(EventSubscriptionService.class);
+        Mockito.when(eventSubscriptionService.getEventSubscriptionBySubscriptionId(any()))
+                .thenReturn(EventNotificationTestUtils.getSampleStoredEventSubscription());
+
+        eventNotificationUtilMockedStatic.when(() -> EventNotificationServiceUtil.validateClientId(anyString()))
+                .thenAnswer((Answer<Void>) invocation -> null);
+        serviceExtensionUtilsMockedStatic.when(() -> ServiceExtensionUtils.isInvokeExternalService(any()))
+                .thenReturn(false);
+
+        defaultEventSubscriptionServiceHandler.setEventSubscriptionService(eventSubscriptionService);
+
+        EventSubscriptionResponse eventSubscriptionRetrieveResponse = defaultEventSubscriptionServiceHandler
+                .getEventSubscription(EventNotificationTestConstants.SAMPLE_CLIENT_ID_2,
                         EventNotificationTestConstants.SAMPLE_SUBSCRIPTION_ID_1);
 
         Assert.assertEquals(eventSubscriptionRetrieveResponse.getResponseStatus(), HttpStatus.SC_BAD_REQUEST);
@@ -468,6 +489,52 @@ public class DefaultEventSubscriptionServiceHandlerTests {
     }
 
     @Test
+    public void testUpdateEventSubscriptionWithClientIdMismatch() throws Exception {
+        EventSubscriptionService eventSubscriptionService = Mockito.mock(EventSubscriptionService.class);
+        Mockito.when(eventSubscriptionService.updateEventSubscription(any())).thenReturn(true);
+        Mockito.when(eventSubscriptionService.getEventSubscriptionBySubscriptionId(any()))
+                .thenReturn(EventNotificationTestUtils.getSampleStoredEventSubscription());
+
+        eventNotificationUtilMockedStatic.when(() -> EventNotificationServiceUtil.validateClientId(anyString()))
+                .thenAnswer((Answer<Void>) invocation -> null);
+        serviceExtensionUtilsMockedStatic.when(() -> ServiceExtensionUtils.isInvokeExternalService(any()))
+                .thenReturn(false);
+
+        defaultEventSubscriptionServiceHandler.setEventSubscriptionService(eventSubscriptionService);
+
+        EventSubscriptionDTO eventSubscriptionUpdateRequestDto = EventNotificationTestUtils.
+                getSampleEventSubscriptionUpdateDTO();
+        eventSubscriptionUpdateRequestDto.setClientId(EventNotificationTestConstants.SAMPLE_CLIENT_ID_2);
+
+        EventSubscriptionResponse eventSubscriptionUpdateResponse = defaultEventSubscriptionServiceHandler
+                .updateEventSubscription(eventSubscriptionUpdateRequestDto);
+
+        Assert.assertEquals(eventSubscriptionUpdateResponse.getResponseStatus(), HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Test
+    public void testUpdateEventSubscriptionNotFound() throws Exception {
+        EventSubscriptionService eventSubscriptionService = Mockito.mock(EventSubscriptionService.class);
+        Mockito.when(eventSubscriptionService.getEventSubscriptionBySubscriptionId(any()))
+                .thenReturn(EventNotificationTestUtils.getSampleStoredEventSubscription());
+        Mockito.when(eventSubscriptionService.updateEventSubscription(any()))
+                .thenThrow(new FSEventNotificationException(EventNotificationConstants.
+                        EVENT_SUBSCRIPTION_NOT_FOUND));
+
+        eventNotificationUtilMockedStatic.when(() -> EventNotificationServiceUtil.validateClientId(anyString()))
+                .thenAnswer((Answer<Void>) invocation -> null);
+        serviceExtensionUtilsMockedStatic.when(() -> ServiceExtensionUtils.isInvokeExternalService(any()))
+                .thenReturn(false);
+
+        defaultEventSubscriptionServiceHandler.setEventSubscriptionService(eventSubscriptionService);
+
+        EventSubscriptionResponse eventSubscriptionUpdateResponse = defaultEventSubscriptionServiceHandler
+                .updateEventSubscription(EventNotificationTestUtils.getSampleEventSubscriptionUpdateDTO());
+
+        Assert.assertEquals(eventSubscriptionUpdateResponse.getResponseStatus(), HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Test
     public void testUpdateEventSubscriptionServiceError() throws Exception {
         EventSubscriptionService eventSubscriptionService = Mockito.mock(EventSubscriptionService.class);
         Mockito.when(eventSubscriptionService.updateEventSubscription(any())).thenReturn(true);
@@ -507,6 +574,27 @@ public class DefaultEventSubscriptionServiceHandlerTests {
                         EventNotificationTestConstants.SAMPLE_SUBSCRIPTION_ID_1);
 
         Assert.assertEquals(eventSubscriptionDeletionResponse.getResponseStatus(), HttpStatus.SC_NO_CONTENT);
+    }
+
+    @Test
+    public void testDeleteEventSubscriptionWithClientIdMismatch() throws Exception {
+        EventSubscriptionService eventSubscriptionService = Mockito.mock(EventSubscriptionService.class);
+        Mockito.when(eventSubscriptionService.deleteEventSubscription(any())).thenReturn(true);
+        Mockito.when(eventSubscriptionService.getEventSubscriptionBySubscriptionId(any()))
+                .thenReturn(EventNotificationTestUtils.getSampleStoredEventSubscription());
+
+        eventNotificationUtilMockedStatic.when(() -> EventNotificationServiceUtil.validateClientId(anyString()))
+                .thenAnswer((Answer<Void>) invocation -> null);
+        serviceExtensionUtilsMockedStatic.when(() -> ServiceExtensionUtils.isInvokeExternalService(any()))
+                .thenReturn(false);
+
+        defaultEventSubscriptionServiceHandler.setEventSubscriptionService(eventSubscriptionService);
+
+        EventSubscriptionResponse eventSubscriptionDeletionResponse = defaultEventSubscriptionServiceHandler
+                .deleteEventSubscription(EventNotificationTestConstants.SAMPLE_CLIENT_ID_2,
+                        EventNotificationTestConstants.SAMPLE_SUBSCRIPTION_ID_1);
+
+        Assert.assertEquals(eventSubscriptionDeletionResponse.getResponseStatus(), HttpStatus.SC_BAD_REQUEST);
     }
 
     @Test


### PR DESCRIPTION
## Fixing security issues in Consent and Event Subscription Modules

> This PR fixes a security issues
> - In the Event Subscription Endpoint where any client can retrieve, modify, and delete event subscriptions of any other client. 
> - Consent File upload endpoint where any client can upload a payment file for another client's consent. 
> - Consent Validate endpoint allows retrieving data of any account without considering the consented accounts

**Issue link:** *https://github.com/wso2-enterprise/security-internals/issues/3350*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [x] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
