### PR TITLE
Setting cookies to https only in consent manager

### DIFF
--- a/financial-services-accelerator/react-apps/self-care-portal/src/main/java/org/wso2/financial/services/accelerator/scp/webapp/service/OAuthService.java
+++ b/financial-services-accelerator/react-apps/self-care-portal/src/main/java/org/wso2/financial/services/accelerator/scp/webapp/service/OAuthService.java
@@ -170,6 +170,7 @@ public class OAuthService {
         cookie.setSecure(true);
         cookie.setMaxAge(maxAge);
         cookie.setPath(path);
+        cookie.setHttpOnly(true);
 
         resp.addCookie(cookie);
     }


### PR DESCRIPTION
## Setting cookies to https only in consent manager

> This PR fixes a security issue in Consent Manager by setting the cookies to HTTP only.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/998*

**Doc Issue:** *Optional, link issue from [documentation repository](https://github.com/wso2/docs-ob/issues)*

**Applicable Labels:** *Spec, product, version, type (specify requested labels)*

------

### Development Checklist

1. [x] Build complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
